### PR TITLE
Removed "fill" method from matrix and vector classes. Also removed product, multiply functions and added them to operation module.

### DIFF
--- a/adaboost/core/data_structures.hpp
+++ b/adaboost/core/data_structures.hpp
@@ -184,43 +184,6 @@ namespace adaboost
                 ~Matrix();
         };
 
-        /* @overload
-        * Used for taking dot product of two vectors.
-        *
-        * @param vec1 First vector in dot product.
-        * @param vec2 Second vector in dot product.
-        * @param result For storing the result.
-        */
-        template <class data_type_vector>
-        void product(const Vector<data_type_vector>& vec1,
-                     const Vector<data_type_vector>& vec2,
-                     data_type_vector& result);
-
-        /* @overload
-        * Used for multiplying a vector
-        * and a matrix.
-        *
-        * @param vec The vector.
-        * @param mat The matrix.
-        * @param result A vector for storing the result.
-        */
-        template <class data_type_vector, class data_type_matrix>
-        void multiply(const Vector<data_type_vector>& vec,
-                     const Matrix<data_type_matrix>& mat,
-                     Vector<data_type_vector>& result);
-
-        /* @overload
-        * Used for multiplyng two matrices.
-        *
-        * @param vec1 First matrix.
-        * @param vec2 Second matrix.
-        * @param result A matrix for storing the result.
-        */
-        template <class data_type_matrix>
-        void multiply(const Matrix<data_type_matrix>& mat1,
-                      const Matrix<data_type_matrix>& mat2,
-                      Matrix<data_type_matrix>& result);
-
     } // namespace core
 } // namespace adaboost
 

--- a/adaboost/core/data_structures.hpp
+++ b/adaboost/core/data_structures.hpp
@@ -67,14 +67,6 @@ namespace adaboost
                          data_type_vector value);
 
                 /*
-                * Used for filling the vector with a given value.
-                *
-                * @param value The value with which the vector is
-                *    to be populated.
-                */
-                void fill(data_type_vector value);
-
-                /*
                 * Used for obtaining the size of the vector.
                 */
                 unsigned int get_size() const;
@@ -157,14 +149,6 @@ namespace adaboost
                 void set(unsigned int x,
                          unsigned int y,
                          data_type_matrix value);
-
-                /*
-                * Used for filling the matrix with a given value.
-                *
-                * @param value The value with which the matrix is
-                *    to be populated.
-                */
-                void fill(data_type_matrix value);
 
                 /*
                 * Used for obtaining number of rows in the vector.

--- a/adaboost/core/data_structures_impl.cpp
+++ b/adaboost/core/data_structures_impl.cpp
@@ -52,16 +52,6 @@ namespace adaboost
         }
 
         template <class data_type_vector>
-        void Vector<data_type_vector>::
-        fill(data_type_vector value)
-        {
-            for(unsigned int i = 0; i < this->size; i++)
-            {
-                this->data[i] = value;
-            }
-        }
-
-        template <class data_type_vector>
         unsigned int Vector<data_type_vector>::get_size() const
         {
             return this->size;
@@ -134,19 +124,6 @@ namespace adaboost
         }
 
         template <class data_type_matrix>
-        void Matrix<data_type_matrix>::
-        fill(data_type_matrix value)
-        {
-            for(unsigned int i = 0; i < this->rows; i++)
-            {
-                for(unsigned int j = 0; j < this->cols; j++)
-                {
-                    this->data[i*this->cols + j] = value;
-                }
-            }
-        }
-
-        template <class data_type_matrix>
         unsigned int Matrix<data_type_matrix>::
         get_rows() const
         {
@@ -173,60 +150,6 @@ namespace adaboost
             if(this->data != NULL)
             {
                 delete [] this->data;
-            }
-        }
-
-        template <class data_type_vector>
-        void product(const Vector<data_type_vector>& vec1,
-                     const Vector<data_type_vector>& vec2,
-                     data_type_vector& result)
-        {
-            adaboost::utils::check(vec1.get_size() == vec2.get_size(),
-                                   "Size of vectors don't match.");
-            result = 0;
-            for(unsigned int i = 0; i < vec1.get_size(); i++)
-            {
-                result += (vec1.at(i)*vec2.at(i));
-            }
-        }
-
-        template <class data_type_vector, class data_type_matrix>
-        void multiply(const Vector<data_type_vector>& vec,
-                     const Matrix<data_type_matrix>& mat,
-                     Vector<data_type_vector>& result)
-        {
-            adaboost::utils::check(vec.get_size() == mat.get_rows(),
-                                  "Orders mismatch in the inputs.");
-            for(unsigned int j = 0; j < mat.get_cols(); j++)
-            {
-                data_type_vector _result = 0;
-                for(unsigned int i = 0; i < mat.get_rows(); i++)
-                {
-                    _result += (vec.at(i)*mat.at(i, j));
-                }
-                result.set(j, _result);
-            }
-        }
-
-        template <class data_type_matrix>
-        void multiply(const Matrix<data_type_matrix>& mat1,
-                     const Matrix<data_type_matrix>& mat2,
-                     Matrix<data_type_matrix>& result)
-        {
-            adaboost::utils::check(mat1.get_cols() == mat2.get_rows(),
-                                    "Order of matrices don't match.");
-            unsigned int common_cols = mat1.get_cols();
-            for(unsigned int i = 0; i < result.get_rows(); i++)
-            {
-                for(unsigned int j = 0; j < result.get_cols(); j++)
-                {
-                    data_type_matrix _result = 0;
-                    for(unsigned int k = 0; k < common_cols; k++)
-                    {
-                        _result += (mat1.at(i, k)*mat2.at(k, j));
-                    }
-                    result.set(i, j, _result);
-                }
             }
         }
 

--- a/adaboost/core/operations.hpp
+++ b/adaboost/core/operations.hpp
@@ -7,6 +7,24 @@ namespace adaboost
 {
     namespace core
     {
+        /* @overload
+        * Used for filling the vector with a given value.
+        *
+        * @param value The value with which the vector is
+        *    to be populated.
+        */
+        template <class data_type_vector>
+        void fill(data_type_vector value);
+
+        /* @overload
+        * Used for filling the matrix with a given value.
+        *
+        * @param value The value with which the matrix is
+        *    to be populated.
+        */
+        template <class data_type_matrix>
+        void fill(data_type_matrix value);
+
         /*
         * This function computes the sum of
         * elements of the given vector and the

--- a/adaboost/core/operations.hpp
+++ b/adaboost/core/operations.hpp
@@ -53,6 +53,44 @@ namespace adaboost
         const Vector<data_type_1>& vec,
         data_type_1& result);
 
+        /*
+        * @overload
+        * Used for taking dot product of two vectors.
+        *
+        * @param vec1 First vector in dot product.
+        * @param vec2 Second vector in dot product.
+        * @param result For storing the result.
+        */
+        template <class data_type_vector>
+        void product(const Vector<data_type_vector>& vec1,
+                     const Vector<data_type_vector>& vec2,
+                     data_type_vector& result);
+
+        /* @overload
+        * Used for multiplyng two matrices.
+        *
+        * @param vec1 First matrix.
+        * @param vec2 Second matrix.
+        * @param result A matrix for storing the result.
+        */
+        template <class data_type_matrix>
+        void multiply(const Matrix<data_type_matrix>& mat1,
+                     const Matrix<data_type_matrix>& mat2,
+                     Matrix<data_type_matrix>& result);
+
+        /* @overload
+        * Used for multiplying a vector
+        * and a matrix.
+        *
+        * @param vec The vector.
+        * @param mat The matrix.
+        * @param result A vector for storing the result.
+        */
+        template <class data_type_vector, class data_type_matrix>
+        void multiply(const Vector<data_type_vector>& vec,
+                     const Matrix<data_type_matrix>& mat,
+                     Vector<data_type_vector>& result);
+
     } // namespace core
 } // namespace adaboost
 

--- a/adaboost/core/operations_impl.cpp
+++ b/adaboost/core/operations_impl.cpp
@@ -48,8 +48,7 @@ namespace adaboost
         }
 
         template <class data_type_vector>
-        void Vector<data_type_vector>::
-        fill(data_type_vector value)
+        void fill(data_type_vector value);
         {
             for(unsigned int i = 0; i < this->size; i++)
             {
@@ -59,8 +58,7 @@ namespace adaboost
 
 
         template <class data_type_matrix>
-        void Matrix<data_type_matrix>::
-        fill(data_type_matrix value)
+        void fill(data_type_matrix value);
         {
             for(unsigned int i = 0; i < this->rows; i++)
             {

--- a/adaboost/core/operations_impl.cpp
+++ b/adaboost/core/operations_impl.cpp
@@ -47,6 +47,86 @@ namespace adaboost
             result = arg_max;
         }
 
+        template <class data_type_vector>
+        void Vector<data_type_vector>::
+        fill(data_type_vector value)
+        {
+            for(unsigned int i = 0; i < this->size; i++)
+            {
+                this->data[i] = value;
+            }
+        }
+
+
+        template <class data_type_matrix>
+        void Matrix<data_type_matrix>::
+        fill(data_type_matrix value)
+        {
+            for(unsigned int i = 0; i < this->rows; i++)
+            {
+                for(unsigned int j = 0; j < this->cols; j++)
+                {
+                    this->data[i*this->cols + j] = value;
+                }
+            }
+        }
+
+
+        template <class data_type_vector, class data_type_matrix>
+        void multiply(const Vector<data_type_vector>& vec,
+                     const Matrix<data_type_matrix>& mat,
+                     Vector<data_type_vector>& result)
+        {
+            adaboost::utils::check(vec.get_size() == mat.get_rows(),
+                                  "Orders mismatch in the inputs.");
+            for(unsigned int j = 0; j < mat.get_cols(); j++)
+            {
+                data_type_vector _result = 0;
+                for(unsigned int i = 0; i < mat.get_rows(); i++)
+                {
+                    _result += (vec.at(i)*mat.at(i, j));
+                }
+                result.set(j, _result);
+            }
+        }
+
+        template <class data_type_matrix>
+        void multiply(const Matrix<data_type_matrix>& mat1,
+                     const Matrix<data_type_matrix>& mat2,
+                     Matrix<data_type_matrix>& result)
+        {
+            adaboost::utils::check(mat1.get_cols() == mat2.get_rows(),
+                                    "Order of matrices don't match.");
+            unsigned int common_cols = mat1.get_cols();
+            for(unsigned int i = 0; i < result.get_rows(); i++)
+            {
+                for(unsigned int j = 0; j < result.get_cols(); j++)
+                {
+                    data_type_matrix _result = 0;
+                    for(unsigned int k = 0; k < common_cols; k++)
+                    {
+                        _result += (mat1.at(i, k)*mat2.at(k, j));
+                    }
+                    result.set(i, j, _result);
+                }
+            }
+        }
+
+        template <class data_type_vector>
+                void product(const Vector<data_type_vector>& vec1,
+                             const Vector<data_type_vector>& vec2,
+                             data_type_vector& result)
+                {
+                    adaboost::utils::check(vec1.get_size() == vec2.get_size(),
+                                           "Size of vectors don't match.");
+                    result = 0;
+                    for(unsigned int i = 0; i < vec1.get_size(); i++)
+                    {
+                        result += (vec1.at(i)*vec2.at(i));
+                    }
+                }
+
+
         #include "instantiated_templates_operations.hpp"
 
     } // namespace core


### PR DESCRIPTION
 #10

Removed `fill` method from the matrix and vector classes present in data structures.hpp and data_structures_impl.cpp and moved them to operations.hpp and operations_impl.cpp.

Also removed multiply, product functions from data structures.hpp and data_structures_impl.cpp and moved them to operations.hpp and operations_impl.cpp.