### PR TITLE
Fix CMake install files from including cuda file when cuda is not built.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,9 +43,15 @@ install(DIRECTORY adaboost DESTINATION ${CMAKE_INSTALL_PREFIX}/include
         PATTERN "*.cpp" EXCLUDE
         PATTERN "tests" EXCLUDE
         )
-install(FILES
-        ${CMAKE_BINARY_DIR}/libs/libadaboost_core.so
-        ${CMAKE_BINARY_DIR}/libs/libadaboost_utils.so
+
+if(BUILD_CUDA)
+    install(FILES
         ${CMAKE_BINARY_DIR}/libs/libadaboost_cuda.so
         ${CMAKE_BINARY_DIR}/libs/libadaboost_cuda_wrappers.so
         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+endif()
+
+install(FILES
+    ${CMAKE_BINARY_DIR}/libs/libadaboost_core.so
+    ${CMAKE_BINARY_DIR}/libs/libadaboost_utils.so
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)


### PR DESCRIPTION
Fixes #25 

#### Brief description of what is fixed or changed
CMakeLists.txt now requires BUILD_CUDA=ON to install libadaboost_cuda_core.so and libadaboost_cuda_utils.so.