### PR TITLE
Non-default streams for filling matrix

### DIFF
--- a/adaboost/core/data_structures.hpp
+++ b/adaboost/core/data_structures.hpp
@@ -176,8 +176,8 @@ namespace adaboost
         * @param result For storing the result.
         */
         template <class data_type_vector>
-        void product(const Vector<data_type_vector>& vec1,
-                     const Vector<data_type_vector>& vec2,
+        void product(Vector<data_type_vector>& vec1,
+                     Vector<data_type_vector>& vec2,
                      data_type_vector& result);
 
         /* @overload
@@ -189,8 +189,8 @@ namespace adaboost
         * @param result A vector for storing the result.
         */
         template <class data_type_vector, class data_type_matrix>
-        void multiply(const Vector<data_type_vector>& vec,
-                     const Matrix<data_type_matrix>& mat,
+        void multiply(Vector<data_type_vector>& vec,
+                     Matrix<data_type_matrix>& mat,
                      Vector<data_type_vector>& result);
 
         /* @overload
@@ -201,8 +201,8 @@ namespace adaboost
         * @param result A matrix for storing the result.
         */
         template <class data_type_matrix>
-        void multiply(const Matrix<data_type_matrix>& mat1,
-                      const Matrix<data_type_matrix>& mat2,
+        void multiply(Matrix<data_type_matrix>& mat1,
+                      Matrix<data_type_matrix>& mat2,
                       Matrix<data_type_matrix>& result);
 
     } // namespace core

--- a/adaboost/core/data_structures_impl.cpp
+++ b/adaboost/core/data_structures_impl.cpp
@@ -154,8 +154,8 @@ namespace adaboost
         }
 
         template <class data_type_vector>
-        void product(const Vector<data_type_vector>& vec1,
-                     const Vector<data_type_vector>& vec2,
+        void product(Vector<data_type_vector>& vec1,
+                     Vector<data_type_vector>& vec2,
                      data_type_vector& result)
         {
             adaboost::utils::check(vec1.get_size() == vec2.get_size(),
@@ -168,8 +168,8 @@ namespace adaboost
         }
 
         template <class data_type_vector, class data_type_matrix>
-        void multiply(const Vector<data_type_vector>& vec,
-                     const Matrix<data_type_matrix>& mat,
+        void multiply(Vector<data_type_vector>& vec,
+                     Matrix<data_type_matrix>& mat,
                      Vector<data_type_vector>& result)
         {
             adaboost::utils::check(vec.get_size() == mat.get_rows(),
@@ -186,8 +186,8 @@ namespace adaboost
         }
 
         template <class data_type_matrix>
-        void multiply(const Matrix<data_type_matrix>& mat1,
-                     const Matrix<data_type_matrix>& mat2,
+        void multiply(Matrix<data_type_matrix>& mat1,
+                     Matrix<data_type_matrix>& mat2,
                      Matrix<data_type_matrix>& result)
         {
             adaboost::utils::check(mat1.get_cols() == mat2.get_rows(),

--- a/adaboost/core/operations.hpp
+++ b/adaboost/core/operations.hpp
@@ -16,7 +16,7 @@ namespace adaboost
         */
 
         template <class data_type_vector>
-        void fill(const data_type_vector value, const Vector<data_type_vector>&vec);
+        void fill(data_type_vector value, Vector<data_type_vector>&vec);
 
 
         /*
@@ -27,7 +27,7 @@ namespace adaboost
         */
 
         template <class data_type_matrix>
-        void fill(const data_type_matrix value, const Matrix<data_type_matrix>&mat);
+        void fill(data_type_matrix value, Matrix<data_type_matrix>&mat);
 
 
         /*
@@ -51,7 +51,7 @@ namespace adaboost
         template <class data_type>
         void Sum(
         data_type (*func_ptr)(data_type),
-        const Vector<data_type>& vec,
+        Vector<data_type>& vec,
         unsigned start,
         unsigned end,
         data_type& result);
@@ -73,7 +73,7 @@ namespace adaboost
         template <class data_type_1, class data_type_2>
         void Argmax(
         data_type_2 (*func_ptr)(data_type_1),
-        const Vector<data_type_1>& vec,
+        Vector<data_type_1>& vec,
         data_type_1& result);
 
     } // namespace core

--- a/adaboost/core/operations_impl.cpp
+++ b/adaboost/core/operations_impl.cpp
@@ -3,7 +3,6 @@
 
 #include<adaboost/utils/utils.hpp>
 #include<adaboost/core/operations.hpp>
-#include<iostream>
 #include<cmath>
 
 namespace adaboost
@@ -12,7 +11,7 @@ namespace adaboost
     {
 
         template <class data_type_vector>
-        void fill(const data_type_vector value, const Vector<data_type_vector>&vec)
+        void fill(data_type_vector value, Vector<data_type_vector>&vec)
         {
             data_type_vector* vecPtr = vec.get_data_pointer();
             std::fill(vecPtr, vecPtr + vec.get_size(), value);
@@ -20,7 +19,7 @@ namespace adaboost
 
 
         template <class data_type_matrix>
-        void fill(data_type_matrix value, const Matrix<data_type_matrix>&mat)
+        void fill(data_type_matrix value, Matrix<data_type_matrix>&mat)
         {
             data_type_matrix* matPtr = mat.get_data_pointer();
             std::fill(matPtr, matPtr + mat.get_rows()*mat.get_cols(), value);
@@ -30,7 +29,7 @@ namespace adaboost
         template <class data_type>
         void Sum(
         data_type (*func_ptr)(data_type),
-        const Vector<data_type>& vec,
+        Vector<data_type>& vec,
         unsigned start,
         unsigned end,
         data_type& result)
@@ -49,7 +48,7 @@ namespace adaboost
         template <class data_type_1, class data_type_2>
         void Argmax(
         data_type_2 (*func_ptr)(data_type_1),
-        const Vector<data_type_1>& vec,
+        Vector<data_type_1>& vec,
         data_type_1& result)
         {
             data_type_2 max_val = func_ptr(vec.at(0));

--- a/adaboost/cuda/core/functions.cu
+++ b/adaboost/cuda/core/functions.cu
@@ -1,0 +1,17 @@
+#ifndef ADABOOST_UTILS_FUNCTION_PARAMS_CU
+#define ADABOOST_UTILS_FUNCTION_PARAMS_CU
+
+namespace adaboost
+{
+    namespace cuda
+    {
+        namespace core
+        {
+
+            __device__ func_t<float, float> p_func;
+
+        }
+    }
+}
+
+#endif

--- a/adaboost/cuda/core/operations.hpp
+++ b/adaboost/cuda/core/operations.hpp
@@ -35,6 +35,18 @@ namespace adaboost
 
             template <class data_type_matrix>
             void fill(const data_type_matrix value, const MatrixGPU<data_type_matrix>&mat, unsigned block_size_x, unsigned block_size_y);
+            
+            /*
+            * This function fills the matrix with a given value.
+            *
+            * If block size x and block size y is passed 0 and 0, values are filled on CPU otherwise they are filled on GPU.
+            *
+            * @param value The value with which the matrix is to be populated.
+            * @param vec The Matrix.
+            */
+
+            template <class data_type_matrix>
+            void fill_streams(const data_type_matrix value, const MatrixGPU<data_type_matrix>&mat, unsigned block_size_x, unsigned block_size_y);
 
 
             /*

--- a/adaboost/cuda/core/operations.hpp
+++ b/adaboost/cuda/core/operations.hpp
@@ -27,10 +27,9 @@ namespace adaboost
             /*
             * This function fills the matrix with a given value.
             *
-            * If block size x and block size y is passed 0 and 0, values are filled on CPU otherwise they are filled on GPU.
-            *
             * @param value The value with which the matrix is to be populated.
-            * @param vec The Matrix.
+            * @param mat The Matrix.
+            * @num_streams Number of streams being used to fill the matrix
             */
 
             template <class data_type_matrix>
@@ -40,6 +39,11 @@ namespace adaboost
             * This function computes
             * dot product of two vectors on
             * GPU.
+            * 
+            * @param vec1 First vector whose product is to be calculated
+            * @param vec2 Second vector whose product is to be calculated
+            * @param result Location to store answer
+            * @param block_size  Number of threads to be launched per block on GPU.
             */
 
             template <class data_type_vector>
@@ -48,6 +52,15 @@ namespace adaboost
             data_type_vector& result,
             unsigned block_size=0);
 
+            /*
+            * This function computes
+            * dot product of two matrices on
+            * GPU.
+            * 
+            * @param mat1 First matrix whose product is to be calculated
+            * @param vec2 Second matrix whose product is to be calculated
+            * @param result Location to store answer
+            */
             template <class data_type_matrix>
             void multiply_gpu(const MatrixGPU<data_type_matrix>& mat1,
             const MatrixGPU<data_type_matrix>& mat2,

--- a/adaboost/cuda/core/operations.hpp
+++ b/adaboost/cuda/core/operations.hpp
@@ -23,6 +23,18 @@ namespace adaboost
 
             template <class data_type_vector>
             void fill(const data_type_vector value, const VectorGPU<data_type_vector>&vec, unsigned block_size);
+            
+            /*
+            * This function fills the matrix with a given value.
+            *
+            * If block size x and block size y is passed 0 and 0, values are filled on CPU otherwise they are filled on GPU.
+            *
+            * @param value The value with which the matrix is to be populated.
+            * @param vec The Matrix.
+            */
+
+            template <class data_type_matrix>
+            void fill(const data_type_matrix value, const MatrixGPU<data_type_matrix>&mat, unsigned block_size_x, unsigned block_size_y);
 
             /*
             * This function fills the matrix with a given value.

--- a/adaboost/cuda/core/operations.hpp
+++ b/adaboost/cuda/core/operations.hpp
@@ -20,21 +20,19 @@ namespace adaboost
             * @param vec The Vector.
             * @param block_size Number of threads to be launched per block on GPU.
             */
-
             template <class data_type_vector>
-            void fill(const data_type_vector value, const VectorGPU<data_type_vector>&vec, unsigned block_size);
-            
+            void fill(data_type_vector value, VectorGPU<data_type_vector>& vec, unsigned block_size);
+
             /*
             * This function fills the matrix with a given value.
             *
             * If block size x and block size y is passed 0 and 0, values are filled on CPU otherwise they are filled on GPU.
             *
             * @param value The value with which the matrix is to be populated.
-            * @param vec The Matrix.
+            * @param mat The Matrix.
             */
-
             template <class data_type_matrix>
-            void fill(const data_type_matrix value, const MatrixGPU<data_type_matrix>&mat, unsigned block_size_x, unsigned block_size_y);
+            void fill(data_type_matrix value, MatrixGPU<data_type_matrix>& mat, unsigned block_size_x, unsigned block_size_y);
 
             /*
             * This function fills the matrix with a given value.
@@ -43,24 +41,22 @@ namespace adaboost
             * @param mat The Matrix.
             * @num_streams Number of streams being used to fill the matrix
             */
-
             template <class data_type_matrix>
-            void fill(const data_type_matrix value, const MatrixGPU<data_type_matrix>& mat, unsigned num_streams);
+            void fill(data_type_matrix value, MatrixGPU<data_type_matrix>& mat, unsigned num_streams);
 
             /*
             * This function computes
             * dot product of two vectors on
             * GPU.
-            * 
+            *
             * @param vec1 First vector whose product is to be calculated
             * @param vec2 Second vector whose product is to be calculated
             * @param result Location to store answer
             * @param block_size  Number of threads to be launched per block on GPU.
             */
-
             template <class data_type_vector>
-            void product_gpu(const VectorGPU<data_type_vector>& vec1,
-            const VectorGPU<data_type_vector>& vec2,
+            void product_gpu(VectorGPU<data_type_vector>& vec1,
+            VectorGPU<data_type_vector>& vec2,
             data_type_vector& result,
             unsigned block_size=0);
 
@@ -68,14 +64,14 @@ namespace adaboost
             * This function computes
             * dot product of two matrices on
             * GPU.
-            * 
+            *
             * @param mat1 First matrix whose product is to be calculated
             * @param vec2 Second matrix whose product is to be calculated
             * @param result Location to store answer
             */
             template <class data_type_matrix>
-            void multiply_gpu(const MatrixGPU<data_type_matrix>& mat1,
-            const MatrixGPU<data_type_matrix>& mat2,
+            void multiply_gpu(MatrixGPU<data_type_matrix>& mat1,
+            MatrixGPU<data_type_matrix>& mat2,
             MatrixGPU<data_type_matrix>& result);
 
 

--- a/adaboost/cuda/core/operations.hpp
+++ b/adaboost/cuda/core/operations.hpp
@@ -34,20 +34,7 @@ namespace adaboost
             */
 
             template <class data_type_matrix>
-            void fill(const data_type_matrix value, const MatrixGPU<data_type_matrix>&mat, unsigned block_size_x, unsigned block_size_y);
-            
-            /*
-            * This function fills the matrix with a given value.
-            *
-            * If block size x and block size y is passed 0 and 0, values are filled on CPU otherwise they are filled on GPU.
-            *
-            * @param value The value with which the matrix is to be populated.
-            * @param vec The Matrix.
-            */
-
-            template <class data_type_matrix>
-            void fill_streams(const data_type_matrix value, const MatrixGPU<data_type_matrix>&mat, unsigned block_size_x, unsigned block_size_y);
-
+            void fill(const data_type_matrix value, const MatrixGPU<data_type_matrix>& mat, unsigned num_streams);
 
             /*
             * This function computes

--- a/adaboost/cuda/core/operations_impl.cu
+++ b/adaboost/cuda/core/operations_impl.cu
@@ -44,7 +44,6 @@ namespace adaboost
                     (vec.get_data_pointer(gpu), vec.get_size(gpu), value);
                 }
             }
-    
             template <class data_type_matrix>
             __global__
             void thread_multi(data_type_matrix *t1, data_type_matrix value, unsigned total_elements){

--- a/adaboost/cuda/core/operations_impl.cu
+++ b/adaboost/cuda/core/operations_impl.cu
@@ -55,6 +55,14 @@ namespace adaboost
             template <class data_type_matrix>
             void fill(const data_type_matrix value, const MatrixGPU<data_type_matrix>& mat, unsigned num_streams)
             {
+                if (num_streams <= 0){
+                    throw "Need positive number of streams";
+                }
+
+                if (num_streams > mat.get_rows()){
+                    num_streams = mat.get_rows();
+                }
+                
                 bool gpu = true;
                 unsigned N=mat.get_cols();
                 unsigned total_elements=mat.get_cols()*mat.get_rows();

--- a/adaboost/cuda/core/operations_impl.cu
+++ b/adaboost/cuda/core/operations_impl.cu
@@ -62,20 +62,20 @@ namespace adaboost
                 if (num_streams > mat.get_rows()){
                     num_streams = mat.get_rows();
                 }
-                
+
                 bool gpu = true;
                 unsigned N=mat.get_cols();
                 unsigned total_elements=mat.get_cols()*mat.get_rows();
                 
                 //array of stream objects
-                cudaStream_t stream[num_streams];
+                adaboost::utils::cuda::cuda_stream_t stream[num_streams];
 
                 for(int i = 0; i < num_streams; i++) {
-                    cudaStreamCreate(&stream[i]);
+                    adaboost::utils::cuda::cuda_stream_create(&stream[i]);
                 }
 
                 for(int i = 0; i < num_streams; i++) {
-                    cudaStreamSynchronize(stream[i]);
+                    adaboost::utils::cuda::cuda_stream_synchronize(stream[i]);
                 }
 
                 for(unsigned row = 0; row < mat.get_rows(); row++) {
@@ -84,11 +84,11 @@ namespace adaboost
                 }
 
                 for(int i = 0;i < num_streams; i++) {
-                    cudaStreamSynchronize(stream[i]);
+                    adaboost::utils::cuda::cuda_stream_synchronize(stream[i]);
                 }
 
                 for (int i = 0; i < num_streams; i++) {
-                    cudaStreamDestroy(stream[i]);
+                    adaboost::utils::cuda::cuda_stream_destroy(stream[i]);
                 }
 
             }

--- a/adaboost/cuda/templates/instantiated_templates_cuda_operations.hpp
+++ b/adaboost/cuda/templates/instantiated_templates_cuda_operations.hpp
@@ -71,4 +71,4 @@ template void multiply_gpu
 const MatrixGPU<long double>& mat2,
 MatrixGPU<long double>& result);
 template void fill<float>(float, adaboost::cuda::core::VectorGPU<float> const&, unsigned int);
-template void fill<float>(float, adaboost::cuda::core::MatrixGPU<float> const&, unsigned int, unsigned int);
+template void fill<float>(float, adaboost::cuda::core::MatrixGPU<float> const&, unsigned int);

--- a/adaboost/cuda/templates/instantiated_templates_cuda_operations.hpp
+++ b/adaboost/cuda/templates/instantiated_templates_cuda_operations.hpp
@@ -1,75 +1,108 @@
 template void product_gpu<bool>(
-const VectorGPU<bool>&, const VectorGPU<bool>&, bool& result, unsigned);
+VectorGPU<bool>&, VectorGPU<bool>&, bool& result, unsigned);
 template void product_gpu<short>(
-const VectorGPU<short>&, const VectorGPU<short>&, short& result, unsigned);
+VectorGPU<short>&, VectorGPU<short>&, short& result, unsigned);
 template void product_gpu<unsigned short>(
-const VectorGPU<unsigned short>&, const VectorGPU<unsigned short>&, unsigned short& result, unsigned);
+VectorGPU<unsigned short>&, VectorGPU<unsigned short>&, unsigned short& result, unsigned);
 template void product_gpu<int>(
-const VectorGPU<int>&, const VectorGPU<int>&, int& result, unsigned);
+VectorGPU<int>&, VectorGPU<int>&, int& result, unsigned);
 template void product_gpu<unsigned int>(
-const VectorGPU<unsigned int>&, const VectorGPU<unsigned int>&, unsigned int& result, unsigned);
+VectorGPU<unsigned int>&, VectorGPU<unsigned int>&, unsigned int& result, unsigned);
 template void product_gpu<long>(
-const VectorGPU<long>&, const VectorGPU<long>&, long& result, unsigned);
+VectorGPU<long>&, VectorGPU<long>&, long& result, unsigned);
 template void product_gpu<unsigned long>(
-const VectorGPU<unsigned long>&, const VectorGPU<unsigned long>&, unsigned long& result, unsigned);
+VectorGPU<unsigned long>&, VectorGPU<unsigned long>&, unsigned long& result, unsigned);
 template void product_gpu<long long>(
-const VectorGPU<long long>&, const VectorGPU<long long>&, long long& result, unsigned);
+VectorGPU<long long>&, VectorGPU<long long>&, long long& result, unsigned);
 template void product_gpu<unsigned long long>(
-const VectorGPU<unsigned long long>&, const VectorGPU<unsigned long long>&, unsigned long long& result, unsigned);
+VectorGPU<unsigned long long>&, VectorGPU<unsigned long long>&, unsigned long long& result, unsigned);
 template void product_gpu<float>(
-const VectorGPU<float>&, const VectorGPU<float>&, float& result, unsigned);
+VectorGPU<float>&, VectorGPU<float>&, float& result, unsigned);
 template void product_gpu<double>(
-const VectorGPU<double>&, const VectorGPU<double>&, double& result, unsigned);
+VectorGPU<double>&, VectorGPU<double>&, double& result, unsigned);
 template void product_gpu<long double>(
-const VectorGPU<long double>&, const VectorGPU<long double>&, long double& result, unsigned);
+VectorGPU<long double>&, VectorGPU<long double>&, long double& result, unsigned);
 template void multiply_gpu
-(const MatrixGPU<bool>& mat1,
-const MatrixGPU<bool>& mat2,
+(MatrixGPU<bool>& mat1,
+MatrixGPU<bool>& mat2,
 MatrixGPU<bool>& result);
 template void multiply_gpu
-(const MatrixGPU<short>& mat1,
-const MatrixGPU<short>& mat2,
+(MatrixGPU<short>& mat1,
+MatrixGPU<short>& mat2,
 MatrixGPU<short>& result);
 template void multiply_gpu
-(const MatrixGPU<unsigned short>& mat1,
-const MatrixGPU<unsigned short>& mat2,
+(MatrixGPU<unsigned short>& mat1,
+MatrixGPU<unsigned short>& mat2,
 MatrixGPU<unsigned short>& result);
 template void multiply_gpu
-(const MatrixGPU<int>& mat1,
-const MatrixGPU<int>& mat2,
+(MatrixGPU<int>& mat1,
+MatrixGPU<int>& mat2,
 MatrixGPU<int>& result);
 template void multiply_gpu
-(const MatrixGPU<unsigned int>& mat1,
-const MatrixGPU<unsigned int>& mat2,
+(MatrixGPU<unsigned int>& mat1,
+MatrixGPU<unsigned int>& mat2,
 MatrixGPU<unsigned int>& result);
 template void multiply_gpu
-(const MatrixGPU<long>& mat1,
-const MatrixGPU<long>& mat2,
+(MatrixGPU<long>& mat1,
+MatrixGPU<long>& mat2,
 MatrixGPU<long>& result);
 template void multiply_gpu
-(const MatrixGPU<unsigned long>& mat1,
-const MatrixGPU<unsigned long>& mat2,
+(MatrixGPU<unsigned long>& mat1,
+MatrixGPU<unsigned long>& mat2,
 MatrixGPU<unsigned long>& result);
 template void multiply_gpu
-(const MatrixGPU<long long>& mat1,
-const MatrixGPU<long long>& mat2,
+(MatrixGPU<long long>& mat1,
+MatrixGPU<long long>& mat2,
 MatrixGPU<long long>& result);
 template void multiply_gpu
-(const MatrixGPU<unsigned long long>& mat1,
-const MatrixGPU<unsigned long long>& mat2,
+(MatrixGPU<unsigned long long>& mat1,
+MatrixGPU<unsigned long long>& mat2,
 MatrixGPU<unsigned long long>& result);
 template void multiply_gpu
-(const MatrixGPU<float>& mat1,
-const MatrixGPU<float>& mat2,
+(MatrixGPU<float>& mat1,
+MatrixGPU<float>& mat2,
 MatrixGPU<float>& result);
 template void multiply_gpu
-(const MatrixGPU<double>& mat1,
-const MatrixGPU<double>& mat2,
+(MatrixGPU<double>& mat1,
+MatrixGPU<double>& mat2,
 MatrixGPU<double>& result);
 template void multiply_gpu
-(const MatrixGPU<long double>& mat1,
-const MatrixGPU<long double>& mat2,
+(MatrixGPU<long double>& mat1,
+MatrixGPU<long double>& mat2,
 MatrixGPU<long double>& result);
-template void fill<float>(float, adaboost::cuda::core::VectorGPU<float> const&, unsigned int);
-template void fill<float>(float, adaboost::cuda::core::MatrixGPU<float> const&, unsigned int, unsigned int);
-template void fill<float>(float, adaboost::cuda::core::MatrixGPU<float> const&, unsigned int);
+template void fill(bool, VectorGPU<bool>&, unsigned int);
+template void fill(short, VectorGPU<short>&, unsigned int);
+template void fill(unsigned short, VectorGPU<unsigned short>&, unsigned int);
+template void fill(int, VectorGPU<int>&, unsigned int);
+template void fill(unsigned int, VectorGPU<unsigned int>&, unsigned int);
+template void fill(long, VectorGPU<long>&, unsigned int);
+template void fill(unsigned long, VectorGPU<unsigned long>&, unsigned int);
+template void fill(long long, VectorGPU<long long>&, unsigned int);
+template void fill(unsigned long long, VectorGPU<unsigned long long>&, unsigned int);
+template void fill(float, VectorGPU<float>&, unsigned int);
+template void fill(double, VectorGPU<double>&, unsigned int);
+template void fill(long double, VectorGPU<long double>&, unsigned int);
+template void fill(bool value, MatrixGPU<bool>&, unsigned block_size_x, unsigned block_size_y);
+template void fill(short value, MatrixGPU<short>&, unsigned block_size_x, unsigned block_size_y);
+template void fill(unsigned short value, MatrixGPU<unsigned short>&, unsigned block_size_x, unsigned block_size_y);
+template void fill(int value, MatrixGPU<int>&, unsigned block_size_x, unsigned block_size_y);
+template void fill(unsigned int value, MatrixGPU<unsigned int>&, unsigned block_size_x, unsigned block_size_y);
+template void fill(long value, MatrixGPU<long>&, unsigned block_size_x, unsigned block_size_y);
+template void fill(unsigned long value, MatrixGPU<unsigned long>&, unsigned block_size_x, unsigned block_size_y);
+template void fill(long long value, MatrixGPU<long long>&, unsigned block_size_x, unsigned block_size_y);
+template void fill(unsigned long long value, MatrixGPU<unsigned long long>&, unsigned block_size_x, unsigned block_size_y);
+template void fill(float value, MatrixGPU<float>&, unsigned block_size_x, unsigned block_size_y);
+template void fill(double value, MatrixGPU<double>&, unsigned block_size_x, unsigned block_size_y);
+template void fill(long double value, MatrixGPU<long double>&, unsigned block_size_x, unsigned block_size_y);
+template void fill(bool value, MatrixGPU<bool>&, unsigned num_streams);
+template void fill(short value, MatrixGPU<short>&, unsigned num_streams);
+template void fill(unsigned short value, MatrixGPU<unsigned short>&, unsigned num_streams);
+template void fill(int value, MatrixGPU<int>&, unsigned num_streams);
+template void fill(unsigned int value, MatrixGPU<unsigned int>&, unsigned num_streams);
+template void fill(long value, MatrixGPU<long>&, unsigned num_streams);
+template void fill(unsigned long value, MatrixGPU<unsigned long>&, unsigned num_streams);
+template void fill(long long value, MatrixGPU<long long>&, unsigned num_streams);
+template void fill(unsigned long long value, MatrixGPU<unsigned long long>&, unsigned num_streams);
+template void fill(float value, MatrixGPU<float>&, unsigned num_streams);
+template void fill(double value, MatrixGPU<double>&, unsigned num_streams);
+template void fill(long double value, MatrixGPU<long double>&, unsigned num_streams);

--- a/adaboost/cuda/templates/instantiated_templates_cuda_operations.hpp
+++ b/adaboost/cuda/templates/instantiated_templates_cuda_operations.hpp
@@ -71,4 +71,5 @@ template void multiply_gpu
 const MatrixGPU<long double>& mat2,
 MatrixGPU<long double>& result);
 template void fill<float>(float, adaboost::cuda::core::VectorGPU<float> const&, unsigned int);
+template void fill<float>(float, adaboost::cuda::core::MatrixGPU<float> const&, unsigned int, unsigned int);
 template void fill<float>(float, adaboost::cuda::core::MatrixGPU<float> const&, unsigned int);

--- a/adaboost/cuda/utils/cuda_wrappers.hpp
+++ b/adaboost/cuda/utils/cuda_wrappers.hpp
@@ -64,24 +64,24 @@ namespace adaboost
 
             /*
             * Creates an asynchronous stream.
-            * 
+            *
             * @param stream The stream to be created
             */
             void cuda_stream_create(cuda_stream_t * stream);
 
             /*
             * Waits for stream tasks to complete.
-            * 
+            *
             * @param stream The stream whose tasks are to be completed
             */
             void cuda_stream_synchronize(cuda_stream_t stream);
 
             /*
             * Destroys and cleans up the asynchronous stream specified.
-            * 
-            * @param stream The stream to destroy 
+            *
+            * @param stream The stream to destroy
             */
-           void cuda_stream_destroy(cuda_stream_t stream);
+            void cuda_stream_destroy(cuda_stream_t stream);
 
         } // namspace cuda
     } // namespace utils

--- a/adaboost/cuda/utils/cuda_wrappers.hpp
+++ b/adaboost/cuda/utils/cuda_wrappers.hpp
@@ -12,6 +12,7 @@ namespace adaboost
         {
             enum direction {HostToDevice, DeviceToHost};
             typedef cudaEvent_t cuda_event_t;
+            typedef cudaStream_t cuda_stream_t;
 
             /*
             * Used for allocating memory on the device.
@@ -60,6 +61,27 @@ namespace adaboost
             * @param ptr Device pointer to memory to free
             */
             void cuda_free(void* ptr);
+
+            /*
+            * Creates an asynchronous stream.
+            * 
+            * @param stream The stream to be created
+            */
+            void cuda_stream_create(cuda_stream_t * stream);
+
+            /*
+            * Waits for stream tasks to complete.
+            * 
+            * @param stream The stream whose tasks are to be completed
+            */
+            void cuda_stream_synchronize(cuda_stream_t stream);
+
+            /*
+            * Destroys and cleans up the asynchronous stream specified.
+            * 
+            * @param stream The stream to destroy 
+            */
+           void cuda_stream_destroy(cuda_stream_t stream);
 
         } // namspace cuda
     } // namespace utils

--- a/adaboost/cuda/utils/cuda_wrappers_impl.hpp
+++ b/adaboost/cuda/utils/cuda_wrappers_impl.hpp
@@ -47,6 +47,21 @@ namespace adaboost
                 cudaFree(ptr);
             }
 
+            void cuda_stream_create(cuda_stream_t * stream)
+            {
+                cudaStreamCreate(stream);    
+            }
+
+            void cuda_stream_synchronize(cuda_stream_t stream)
+            {
+                cudaStreamSynchronize(stream);
+            }
+
+           void cuda_stream_destroy(cuda_stream_t stream)
+           {
+               cudaStreamDestroy(stream);
+           }
+
         } // namespace cuda
     } // namespace utils
 } // namespace adaboost

--- a/adaboost/cuda/utils/cuda_wrappers_impl.hpp
+++ b/adaboost/cuda/utils/cuda_wrappers_impl.hpp
@@ -14,8 +14,7 @@ namespace adaboost
                 cudaMalloc(ptr, num_bytes);
             }
 
-            void cuda_memcpy
-            (void* ptr_1, void* ptr_2, unsigned num_bytes, direction d)
+            void cuda_memcpy(void* ptr_1, void* ptr_2, unsigned num_bytes, direction d)
             {
                 if(d == HostToDevice)
                 {
@@ -49,7 +48,7 @@ namespace adaboost
 
             void cuda_stream_create(cuda_stream_t * stream)
             {
-                cudaStreamCreate(stream);    
+                cudaStreamCreate(stream);
             }
 
             void cuda_stream_synchronize(cuda_stream_t stream)

--- a/adaboost/templates/instantiated_templates_data_structures.hpp
+++ b/adaboost/templates/instantiated_templates_data_structures.hpp
@@ -26,340 +26,340 @@ template class Matrix<float>;
 template class Matrix<double>;
 template class Matrix<long double>;
 template void product<bool>
-(const Vector<bool>&, const Vector<bool>&, bool&);
+(Vector<bool>&, Vector<bool>&, bool&);
 template void product<short>
-(const Vector<short>&, const Vector<short>&, short&);
+(Vector<short>&, Vector<short>&, short&);
 template void product<unsigned short>
-(const Vector<unsigned short>&, const Vector<unsigned short>&, unsigned short&);
+(Vector<unsigned short>&, Vector<unsigned short>&, unsigned short&);
 template void product<int>
-(const Vector<int>&, const Vector<int>&, int&);
+(Vector<int>&, Vector<int>&, int&);
 template void product<unsigned int>
-(const Vector<unsigned int>&, const Vector<unsigned int>&, unsigned int&);
+(Vector<unsigned int>&, Vector<unsigned int>&, unsigned int&);
 template void product<long>
-(const Vector<long>&, const Vector<long>&, long&);
+(Vector<long>&, Vector<long>&, long&);
 template void product<unsigned long>
-(const Vector<unsigned long>&, const Vector<unsigned long>&, unsigned long&);
+(Vector<unsigned long>&, Vector<unsigned long>&, unsigned long&);
 template void product<long long>
-(const Vector<long long>&, const Vector<long long>&, long long&);
+(Vector<long long>&, Vector<long long>&, long long&);
 template void product<unsigned long long>
-(const Vector<unsigned long long>&, const Vector<unsigned long long>&, unsigned long long&);
+(Vector<unsigned long long>&, Vector<unsigned long long>&, unsigned long long&);
 template void product<float>
-(const Vector<float>&, const Vector<float>&, float&);
+(Vector<float>&, Vector<float>&, float&);
 template void product<double>
-(const Vector<double>&, const Vector<double>&, double&);
+(Vector<double>&, Vector<double>&, double&);
 template void product<long double>
-(const Vector<long double>&, const Vector<long double>&, long double&);
+(Vector<long double>&, Vector<long double>&, long double&);
 template void multiply<bool>
-(const Matrix<bool>&, const Matrix<bool>&, Matrix<bool>&);
+(Matrix<bool>&, Matrix<bool>&, Matrix<bool>&);
 template void multiply<short>
-(const Matrix<short>&, const Matrix<short>&, Matrix<short>&);
+(Matrix<short>&, Matrix<short>&, Matrix<short>&);
 template void multiply<unsigned short>
-(const Matrix<unsigned short>&, const Matrix<unsigned short>&, Matrix<unsigned short>&);
+(Matrix<unsigned short>&, Matrix<unsigned short>&, Matrix<unsigned short>&);
 template void multiply<int>
-(const Matrix<int>&, const Matrix<int>&, Matrix<int>&);
+(Matrix<int>&, Matrix<int>&, Matrix<int>&);
 template void multiply<unsigned int>
-(const Matrix<unsigned int>&, const Matrix<unsigned int>&, Matrix<unsigned int>&);
+(Matrix<unsigned int>&, Matrix<unsigned int>&, Matrix<unsigned int>&);
 template void multiply<long>
-(const Matrix<long>&, const Matrix<long>&, Matrix<long>&);
+(Matrix<long>&, Matrix<long>&, Matrix<long>&);
 template void multiply<unsigned long>
-(const Matrix<unsigned long>&, const Matrix<unsigned long>&, Matrix<unsigned long>&);
+(Matrix<unsigned long>&, Matrix<unsigned long>&, Matrix<unsigned long>&);
 template void multiply<long long>
-(const Matrix<long long>&, const Matrix<long long>&, Matrix<long long>&);
+(Matrix<long long>&, Matrix<long long>&, Matrix<long long>&);
 template void multiply<unsigned long long>
-(const Matrix<unsigned long long>&, const Matrix<unsigned long long>&, Matrix<unsigned long long>&);
+(Matrix<unsigned long long>&, Matrix<unsigned long long>&, Matrix<unsigned long long>&);
 template void multiply<float>
-(const Matrix<float>&, const Matrix<float>&, Matrix<float>&);
+(Matrix<float>&, Matrix<float>&, Matrix<float>&);
 template void multiply<double>
-(const Matrix<double>&, const Matrix<double>&, Matrix<double>&);
+(Matrix<double>&, Matrix<double>&, Matrix<double>&);
 template void multiply<long double>
-(const Matrix<long double>&, const Matrix<long double>&, Matrix<long double>&);
+(Matrix<long double>&, Matrix<long double>&, Matrix<long double>&);
 template void multiply<bool, bool>
-(const Vector<bool>&, const Matrix<bool>&, Vector<bool>&);
+(Vector<bool>&, Matrix<bool>&, Vector<bool>&);
 template void multiply<bool, short>
-(const Vector<bool>&, const Matrix<short>&, Vector<bool>&);
+(Vector<bool>&, Matrix<short>&, Vector<bool>&);
 template void multiply<bool, unsigned short>
-(const Vector<bool>&, const Matrix<unsigned short>&, Vector<bool>&);
+(Vector<bool>&, Matrix<unsigned short>&, Vector<bool>&);
 template void multiply<bool, int>
-(const Vector<bool>&, const Matrix<int>&, Vector<bool>&);
+(Vector<bool>&, Matrix<int>&, Vector<bool>&);
 template void multiply<bool, unsigned int>
-(const Vector<bool>&, const Matrix<unsigned int>&, Vector<bool>&);
+(Vector<bool>&, Matrix<unsigned int>&, Vector<bool>&);
 template void multiply<bool, long>
-(const Vector<bool>&, const Matrix<long>&, Vector<bool>&);
+(Vector<bool>&, Matrix<long>&, Vector<bool>&);
 template void multiply<bool, unsigned long>
-(const Vector<bool>&, const Matrix<unsigned long>&, Vector<bool>&);
+(Vector<bool>&, Matrix<unsigned long>&, Vector<bool>&);
 template void multiply<bool, long long>
-(const Vector<bool>&, const Matrix<long long>&, Vector<bool>&);
+(Vector<bool>&, Matrix<long long>&, Vector<bool>&);
 template void multiply<bool, unsigned long long>
-(const Vector<bool>&, const Matrix<unsigned long long>&, Vector<bool>&);
+(Vector<bool>&, Matrix<unsigned long long>&, Vector<bool>&);
 template void multiply<bool, float>
-(const Vector<bool>&, const Matrix<float>&, Vector<bool>&);
+(Vector<bool>&, Matrix<float>&, Vector<bool>&);
 template void multiply<bool, double>
-(const Vector<bool>&, const Matrix<double>&, Vector<bool>&);
+(Vector<bool>&, Matrix<double>&, Vector<bool>&);
 template void multiply<bool, long double>
-(const Vector<bool>&, const Matrix<long double>&, Vector<bool>&);
+(Vector<bool>&, Matrix<long double>&, Vector<bool>&);
 template void multiply<short, bool>
-(const Vector<short>&, const Matrix<bool>&, Vector<short>&);
+(Vector<short>&, Matrix<bool>&, Vector<short>&);
 template void multiply<short, short>
-(const Vector<short>&, const Matrix<short>&, Vector<short>&);
+(Vector<short>&, Matrix<short>&, Vector<short>&);
 template void multiply<short, unsigned short>
-(const Vector<short>&, const Matrix<unsigned short>&, Vector<short>&);
+(Vector<short>&, Matrix<unsigned short>&, Vector<short>&);
 template void multiply<short, int>
-(const Vector<short>&, const Matrix<int>&, Vector<short>&);
+(Vector<short>&, Matrix<int>&, Vector<short>&);
 template void multiply<short, unsigned int>
-(const Vector<short>&, const Matrix<unsigned int>&, Vector<short>&);
+(Vector<short>&, Matrix<unsigned int>&, Vector<short>&);
 template void multiply<short, long>
-(const Vector<short>&, const Matrix<long>&, Vector<short>&);
+(Vector<short>&, Matrix<long>&, Vector<short>&);
 template void multiply<short, unsigned long>
-(const Vector<short>&, const Matrix<unsigned long>&, Vector<short>&);
+(Vector<short>&, Matrix<unsigned long>&, Vector<short>&);
 template void multiply<short, long long>
-(const Vector<short>&, const Matrix<long long>&, Vector<short>&);
+(Vector<short>&, Matrix<long long>&, Vector<short>&);
 template void multiply<short, unsigned long long>
-(const Vector<short>&, const Matrix<unsigned long long>&, Vector<short>&);
+(Vector<short>&, Matrix<unsigned long long>&, Vector<short>&);
 template void multiply<short, float>
-(const Vector<short>&, const Matrix<float>&, Vector<short>&);
+(Vector<short>&, Matrix<float>&, Vector<short>&);
 template void multiply<short, double>
-(const Vector<short>&, const Matrix<double>&, Vector<short>&);
+(Vector<short>&, Matrix<double>&, Vector<short>&);
 template void multiply<short, long double>
-(const Vector<short>&, const Matrix<long double>&, Vector<short>&);
+(Vector<short>&, Matrix<long double>&, Vector<short>&);
 template void multiply<unsigned short, bool>
-(const Vector<unsigned short>&, const Matrix<bool>&, Vector<unsigned short>&);
+(Vector<unsigned short>&, Matrix<bool>&, Vector<unsigned short>&);
 template void multiply<unsigned short, short>
-(const Vector<unsigned short>&, const Matrix<short>&, Vector<unsigned short>&);
+(Vector<unsigned short>&, Matrix<short>&, Vector<unsigned short>&);
 template void multiply<unsigned short, unsigned short>
-(const Vector<unsigned short>&, const Matrix<unsigned short>&, Vector<unsigned short>&);
+(Vector<unsigned short>&, Matrix<unsigned short>&, Vector<unsigned short>&);
 template void multiply<unsigned short, int>
-(const Vector<unsigned short>&, const Matrix<int>&, Vector<unsigned short>&);
+(Vector<unsigned short>&, Matrix<int>&, Vector<unsigned short>&);
 template void multiply<unsigned short, unsigned int>
-(const Vector<unsigned short>&, const Matrix<unsigned int>&, Vector<unsigned short>&);
+(Vector<unsigned short>&, Matrix<unsigned int>&, Vector<unsigned short>&);
 template void multiply<unsigned short, long>
-(const Vector<unsigned short>&, const Matrix<long>&, Vector<unsigned short>&);
+(Vector<unsigned short>&, Matrix<long>&, Vector<unsigned short>&);
 template void multiply<unsigned short, unsigned long>
-(const Vector<unsigned short>&, const Matrix<unsigned long>&, Vector<unsigned short>&);
+(Vector<unsigned short>&, Matrix<unsigned long>&, Vector<unsigned short>&);
 template void multiply<unsigned short, long long>
-(const Vector<unsigned short>&, const Matrix<long long>&, Vector<unsigned short>&);
+(Vector<unsigned short>&, Matrix<long long>&, Vector<unsigned short>&);
 template void multiply<unsigned short, unsigned long long>
-(const Vector<unsigned short>&, const Matrix<unsigned long long>&, Vector<unsigned short>&);
+(Vector<unsigned short>&, Matrix<unsigned long long>&, Vector<unsigned short>&);
 template void multiply<unsigned short, float>
-(const Vector<unsigned short>&, const Matrix<float>&, Vector<unsigned short>&);
+(Vector<unsigned short>&, Matrix<float>&, Vector<unsigned short>&);
 template void multiply<unsigned short, double>
-(const Vector<unsigned short>&, const Matrix<double>&, Vector<unsigned short>&);
+(Vector<unsigned short>&, Matrix<double>&, Vector<unsigned short>&);
 template void multiply<unsigned short, long double>
-(const Vector<unsigned short>&, const Matrix<long double>&, Vector<unsigned short>&);
+(Vector<unsigned short>&, Matrix<long double>&, Vector<unsigned short>&);
 template void multiply<int, bool>
-(const Vector<int>&, const Matrix<bool>&, Vector<int>&);
+(Vector<int>&, Matrix<bool>&, Vector<int>&);
 template void multiply<int, short>
-(const Vector<int>&, const Matrix<short>&, Vector<int>&);
+(Vector<int>&, Matrix<short>&, Vector<int>&);
 template void multiply<int, unsigned short>
-(const Vector<int>&, const Matrix<unsigned short>&, Vector<int>&);
+(Vector<int>&, Matrix<unsigned short>&, Vector<int>&);
 template void multiply<int, int>
-(const Vector<int>&, const Matrix<int>&, Vector<int>&);
+(Vector<int>&, Matrix<int>&, Vector<int>&);
 template void multiply<int, unsigned int>
-(const Vector<int>&, const Matrix<unsigned int>&, Vector<int>&);
+(Vector<int>&, Matrix<unsigned int>&, Vector<int>&);
 template void multiply<int, long>
-(const Vector<int>&, const Matrix<long>&, Vector<int>&);
+(Vector<int>&, Matrix<long>&, Vector<int>&);
 template void multiply<int, unsigned long>
-(const Vector<int>&, const Matrix<unsigned long>&, Vector<int>&);
+(Vector<int>&, Matrix<unsigned long>&, Vector<int>&);
 template void multiply<int, long long>
-(const Vector<int>&, const Matrix<long long>&, Vector<int>&);
+(Vector<int>&, Matrix<long long>&, Vector<int>&);
 template void multiply<int, unsigned long long>
-(const Vector<int>&, const Matrix<unsigned long long>&, Vector<int>&);
+(Vector<int>&, Matrix<unsigned long long>&, Vector<int>&);
 template void multiply<int, float>
-(const Vector<int>&, const Matrix<float>&, Vector<int>&);
+(Vector<int>&, Matrix<float>&, Vector<int>&);
 template void multiply<int, double>
-(const Vector<int>&, const Matrix<double>&, Vector<int>&);
+(Vector<int>&, Matrix<double>&, Vector<int>&);
 template void multiply<int, long double>
-(const Vector<int>&, const Matrix<long double>&, Vector<int>&);
+(Vector<int>&, Matrix<long double>&, Vector<int>&);
 template void multiply<unsigned int, bool>
-(const Vector<unsigned int>&, const Matrix<bool>&, Vector<unsigned int>&);
+(Vector<unsigned int>&, Matrix<bool>&, Vector<unsigned int>&);
 template void multiply<unsigned int, short>
-(const Vector<unsigned int>&, const Matrix<short>&, Vector<unsigned int>&);
+(Vector<unsigned int>&, Matrix<short>&, Vector<unsigned int>&);
 template void multiply<unsigned int, unsigned short>
-(const Vector<unsigned int>&, const Matrix<unsigned short>&, Vector<unsigned int>&);
+(Vector<unsigned int>&, Matrix<unsigned short>&, Vector<unsigned int>&);
 template void multiply<unsigned int, int>
-(const Vector<unsigned int>&, const Matrix<int>&, Vector<unsigned int>&);
+(Vector<unsigned int>&, Matrix<int>&, Vector<unsigned int>&);
 template void multiply<unsigned int, unsigned int>
-(const Vector<unsigned int>&, const Matrix<unsigned int>&, Vector<unsigned int>&);
+(Vector<unsigned int>&, Matrix<unsigned int>&, Vector<unsigned int>&);
 template void multiply<unsigned int, long>
-(const Vector<unsigned int>&, const Matrix<long>&, Vector<unsigned int>&);
+(Vector<unsigned int>&, Matrix<long>&, Vector<unsigned int>&);
 template void multiply<unsigned int, unsigned long>
-(const Vector<unsigned int>&, const Matrix<unsigned long>&, Vector<unsigned int>&);
+(Vector<unsigned int>&, Matrix<unsigned long>&, Vector<unsigned int>&);
 template void multiply<unsigned int, long long>
-(const Vector<unsigned int>&, const Matrix<long long>&, Vector<unsigned int>&);
+(Vector<unsigned int>&, Matrix<long long>&, Vector<unsigned int>&);
 template void multiply<unsigned int, unsigned long long>
-(const Vector<unsigned int>&, const Matrix<unsigned long long>&, Vector<unsigned int>&);
+(Vector<unsigned int>&, Matrix<unsigned long long>&, Vector<unsigned int>&);
 template void multiply<unsigned int, float>
-(const Vector<unsigned int>&, const Matrix<float>&, Vector<unsigned int>&);
+(Vector<unsigned int>&, Matrix<float>&, Vector<unsigned int>&);
 template void multiply<unsigned int, double>
-(const Vector<unsigned int>&, const Matrix<double>&, Vector<unsigned int>&);
+(Vector<unsigned int>&, Matrix<double>&, Vector<unsigned int>&);
 template void multiply<unsigned int, long double>
-(const Vector<unsigned int>&, const Matrix<long double>&, Vector<unsigned int>&);
+(Vector<unsigned int>&, Matrix<long double>&, Vector<unsigned int>&);
 template void multiply<long, bool>
-(const Vector<long>&, const Matrix<bool>&, Vector<long>&);
+(Vector<long>&, Matrix<bool>&, Vector<long>&);
 template void multiply<long, short>
-(const Vector<long>&, const Matrix<short>&, Vector<long>&);
+(Vector<long>&, Matrix<short>&, Vector<long>&);
 template void multiply<long, unsigned short>
-(const Vector<long>&, const Matrix<unsigned short>&, Vector<long>&);
+(Vector<long>&, Matrix<unsigned short>&, Vector<long>&);
 template void multiply<long, int>
-(const Vector<long>&, const Matrix<int>&, Vector<long>&);
+(Vector<long>&, Matrix<int>&, Vector<long>&);
 template void multiply<long, unsigned int>
-(const Vector<long>&, const Matrix<unsigned int>&, Vector<long>&);
+(Vector<long>&, Matrix<unsigned int>&, Vector<long>&);
 template void multiply<long, long>
-(const Vector<long>&, const Matrix<long>&, Vector<long>&);
+(Vector<long>&, Matrix<long>&, Vector<long>&);
 template void multiply<long, unsigned long>
-(const Vector<long>&, const Matrix<unsigned long>&, Vector<long>&);
+(Vector<long>&, Matrix<unsigned long>&, Vector<long>&);
 template void multiply<long, long long>
-(const Vector<long>&, const Matrix<long long>&, Vector<long>&);
+(Vector<long>&, Matrix<long long>&, Vector<long>&);
 template void multiply<long, unsigned long long>
-(const Vector<long>&, const Matrix<unsigned long long>&, Vector<long>&);
+(Vector<long>&, Matrix<unsigned long long>&, Vector<long>&);
 template void multiply<long, float>
-(const Vector<long>&, const Matrix<float>&, Vector<long>&);
+(Vector<long>&, Matrix<float>&, Vector<long>&);
 template void multiply<long, double>
-(const Vector<long>&, const Matrix<double>&, Vector<long>&);
+(Vector<long>&, Matrix<double>&, Vector<long>&);
 template void multiply<long, long double>
-(const Vector<long>&, const Matrix<long double>&, Vector<long>&);
+(Vector<long>&, Matrix<long double>&, Vector<long>&);
 template void multiply<unsigned long, bool>
-(const Vector<unsigned long>&, const Matrix<bool>&, Vector<unsigned long>&);
+(Vector<unsigned long>&, Matrix<bool>&, Vector<unsigned long>&);
 template void multiply<unsigned long, short>
-(const Vector<unsigned long>&, const Matrix<short>&, Vector<unsigned long>&);
+(Vector<unsigned long>&, Matrix<short>&, Vector<unsigned long>&);
 template void multiply<unsigned long, unsigned short>
-(const Vector<unsigned long>&, const Matrix<unsigned short>&, Vector<unsigned long>&);
+(Vector<unsigned long>&, Matrix<unsigned short>&, Vector<unsigned long>&);
 template void multiply<unsigned long, int>
-(const Vector<unsigned long>&, const Matrix<int>&, Vector<unsigned long>&);
+(Vector<unsigned long>&, Matrix<int>&, Vector<unsigned long>&);
 template void multiply<unsigned long, unsigned int>
-(const Vector<unsigned long>&, const Matrix<unsigned int>&, Vector<unsigned long>&);
+(Vector<unsigned long>&, Matrix<unsigned int>&, Vector<unsigned long>&);
 template void multiply<unsigned long, long>
-(const Vector<unsigned long>&, const Matrix<long>&, Vector<unsigned long>&);
+(Vector<unsigned long>&, Matrix<long>&, Vector<unsigned long>&);
 template void multiply<unsigned long, unsigned long>
-(const Vector<unsigned long>&, const Matrix<unsigned long>&, Vector<unsigned long>&);
+(Vector<unsigned long>&, Matrix<unsigned long>&, Vector<unsigned long>&);
 template void multiply<unsigned long, long long>
-(const Vector<unsigned long>&, const Matrix<long long>&, Vector<unsigned long>&);
+(Vector<unsigned long>&, Matrix<long long>&, Vector<unsigned long>&);
 template void multiply<unsigned long, unsigned long long>
-(const Vector<unsigned long>&, const Matrix<unsigned long long>&, Vector<unsigned long>&);
+(Vector<unsigned long>&, Matrix<unsigned long long>&, Vector<unsigned long>&);
 template void multiply<unsigned long, float>
-(const Vector<unsigned long>&, const Matrix<float>&, Vector<unsigned long>&);
+(Vector<unsigned long>&, Matrix<float>&, Vector<unsigned long>&);
 template void multiply<unsigned long, double>
-(const Vector<unsigned long>&, const Matrix<double>&, Vector<unsigned long>&);
+(Vector<unsigned long>&, Matrix<double>&, Vector<unsigned long>&);
 template void multiply<unsigned long, long double>
-(const Vector<unsigned long>&, const Matrix<long double>&, Vector<unsigned long>&);
+(Vector<unsigned long>&, Matrix<long double>&, Vector<unsigned long>&);
 template void multiply<long long, bool>
-(const Vector<long long>&, const Matrix<bool>&, Vector<long long>&);
+(Vector<long long>&, Matrix<bool>&, Vector<long long>&);
 template void multiply<long long, short>
-(const Vector<long long>&, const Matrix<short>&, Vector<long long>&);
+(Vector<long long>&, Matrix<short>&, Vector<long long>&);
 template void multiply<long long, unsigned short>
-(const Vector<long long>&, const Matrix<unsigned short>&, Vector<long long>&);
+(Vector<long long>&, Matrix<unsigned short>&, Vector<long long>&);
 template void multiply<long long, int>
-(const Vector<long long>&, const Matrix<int>&, Vector<long long>&);
+(Vector<long long>&, Matrix<int>&, Vector<long long>&);
 template void multiply<long long, unsigned int>
-(const Vector<long long>&, const Matrix<unsigned int>&, Vector<long long>&);
+(Vector<long long>&, Matrix<unsigned int>&, Vector<long long>&);
 template void multiply<long long, long>
-(const Vector<long long>&, const Matrix<long>&, Vector<long long>&);
+(Vector<long long>&, Matrix<long>&, Vector<long long>&);
 template void multiply<long long, unsigned long>
-(const Vector<long long>&, const Matrix<unsigned long>&, Vector<long long>&);
+(Vector<long long>&, Matrix<unsigned long>&, Vector<long long>&);
 template void multiply<long long, long long>
-(const Vector<long long>&, const Matrix<long long>&, Vector<long long>&);
+(Vector<long long>&, Matrix<long long>&, Vector<long long>&);
 template void multiply<long long, unsigned long long>
-(const Vector<long long>&, const Matrix<unsigned long long>&, Vector<long long>&);
+(Vector<long long>&, Matrix<unsigned long long>&, Vector<long long>&);
 template void multiply<long long, float>
-(const Vector<long long>&, const Matrix<float>&, Vector<long long>&);
+(Vector<long long>&, Matrix<float>&, Vector<long long>&);
 template void multiply<long long, double>
-(const Vector<long long>&, const Matrix<double>&, Vector<long long>&);
+(Vector<long long>&, Matrix<double>&, Vector<long long>&);
 template void multiply<long long, long double>
-(const Vector<long long>&, const Matrix<long double>&, Vector<long long>&);
+(Vector<long long>&, Matrix<long double>&, Vector<long long>&);
 template void multiply<unsigned long long, bool>
-(const Vector<unsigned long long>&, const Matrix<bool>&, Vector<unsigned long long>&);
+(Vector<unsigned long long>&, Matrix<bool>&, Vector<unsigned long long>&);
 template void multiply<unsigned long long, short>
-(const Vector<unsigned long long>&, const Matrix<short>&, Vector<unsigned long long>&);
+(Vector<unsigned long long>&, Matrix<short>&, Vector<unsigned long long>&);
 template void multiply<unsigned long long, unsigned short>
-(const Vector<unsigned long long>&, const Matrix<unsigned short>&, Vector<unsigned long long>&);
+(Vector<unsigned long long>&, Matrix<unsigned short>&, Vector<unsigned long long>&);
 template void multiply<unsigned long long, int>
-(const Vector<unsigned long long>&, const Matrix<int>&, Vector<unsigned long long>&);
+(Vector<unsigned long long>&, Matrix<int>&, Vector<unsigned long long>&);
 template void multiply<unsigned long long, unsigned int>
-(const Vector<unsigned long long>&, const Matrix<unsigned int>&, Vector<unsigned long long>&);
+(Vector<unsigned long long>&, Matrix<unsigned int>&, Vector<unsigned long long>&);
 template void multiply<unsigned long long, long>
-(const Vector<unsigned long long>&, const Matrix<long>&, Vector<unsigned long long>&);
+(Vector<unsigned long long>&, Matrix<long>&, Vector<unsigned long long>&);
 template void multiply<unsigned long long, unsigned long>
-(const Vector<unsigned long long>&, const Matrix<unsigned long>&, Vector<unsigned long long>&);
+(Vector<unsigned long long>&, Matrix<unsigned long>&, Vector<unsigned long long>&);
 template void multiply<unsigned long long, long long>
-(const Vector<unsigned long long>&, const Matrix<long long>&, Vector<unsigned long long>&);
+(Vector<unsigned long long>&, Matrix<long long>&, Vector<unsigned long long>&);
 template void multiply<unsigned long long, unsigned long long>
-(const Vector<unsigned long long>&, const Matrix<unsigned long long>&, Vector<unsigned long long>&);
+(Vector<unsigned long long>&, Matrix<unsigned long long>&, Vector<unsigned long long>&);
 template void multiply<unsigned long long, float>
-(const Vector<unsigned long long>&, const Matrix<float>&, Vector<unsigned long long>&);
+(Vector<unsigned long long>&, Matrix<float>&, Vector<unsigned long long>&);
 template void multiply<unsigned long long, double>
-(const Vector<unsigned long long>&, const Matrix<double>&, Vector<unsigned long long>&);
+(Vector<unsigned long long>&, Matrix<double>&, Vector<unsigned long long>&);
 template void multiply<unsigned long long, long double>
-(const Vector<unsigned long long>&, const Matrix<long double>&, Vector<unsigned long long>&);
+(Vector<unsigned long long>&, Matrix<long double>&, Vector<unsigned long long>&);
 template void multiply<float, bool>
-(const Vector<float>&, const Matrix<bool>&, Vector<float>&);
+(Vector<float>&, Matrix<bool>&, Vector<float>&);
 template void multiply<float, short>
-(const Vector<float>&, const Matrix<short>&, Vector<float>&);
+(Vector<float>&, Matrix<short>&, Vector<float>&);
 template void multiply<float, unsigned short>
-(const Vector<float>&, const Matrix<unsigned short>&, Vector<float>&);
+(Vector<float>&, Matrix<unsigned short>&, Vector<float>&);
 template void multiply<float, int>
-(const Vector<float>&, const Matrix<int>&, Vector<float>&);
+(Vector<float>&, Matrix<int>&, Vector<float>&);
 template void multiply<float, unsigned int>
-(const Vector<float>&, const Matrix<unsigned int>&, Vector<float>&);
+(Vector<float>&, Matrix<unsigned int>&, Vector<float>&);
 template void multiply<float, long>
-(const Vector<float>&, const Matrix<long>&, Vector<float>&);
+(Vector<float>&, Matrix<long>&, Vector<float>&);
 template void multiply<float, unsigned long>
-(const Vector<float>&, const Matrix<unsigned long>&, Vector<float>&);
+(Vector<float>&, Matrix<unsigned long>&, Vector<float>&);
 template void multiply<float, long long>
-(const Vector<float>&, const Matrix<long long>&, Vector<float>&);
+(Vector<float>&, Matrix<long long>&, Vector<float>&);
 template void multiply<float, unsigned long long>
-(const Vector<float>&, const Matrix<unsigned long long>&, Vector<float>&);
+(Vector<float>&, Matrix<unsigned long long>&, Vector<float>&);
 template void multiply<float, float>
-(const Vector<float>&, const Matrix<float>&, Vector<float>&);
+(Vector<float>&, Matrix<float>&, Vector<float>&);
 template void multiply<float, double>
-(const Vector<float>&, const Matrix<double>&, Vector<float>&);
+(Vector<float>&, Matrix<double>&, Vector<float>&);
 template void multiply<float, long double>
-(const Vector<float>&, const Matrix<long double>&, Vector<float>&);
+(Vector<float>&, Matrix<long double>&, Vector<float>&);
 template void multiply<double, bool>
-(const Vector<double>&, const Matrix<bool>&, Vector<double>&);
+(Vector<double>&, Matrix<bool>&, Vector<double>&);
 template void multiply<double, short>
-(const Vector<double>&, const Matrix<short>&, Vector<double>&);
+(Vector<double>&, Matrix<short>&, Vector<double>&);
 template void multiply<double, unsigned short>
-(const Vector<double>&, const Matrix<unsigned short>&, Vector<double>&);
+(Vector<double>&, Matrix<unsigned short>&, Vector<double>&);
 template void multiply<double, int>
-(const Vector<double>&, const Matrix<int>&, Vector<double>&);
+(Vector<double>&, Matrix<int>&, Vector<double>&);
 template void multiply<double, unsigned int>
-(const Vector<double>&, const Matrix<unsigned int>&, Vector<double>&);
+(Vector<double>&, Matrix<unsigned int>&, Vector<double>&);
 template void multiply<double, long>
-(const Vector<double>&, const Matrix<long>&, Vector<double>&);
+(Vector<double>&, Matrix<long>&, Vector<double>&);
 template void multiply<double, unsigned long>
-(const Vector<double>&, const Matrix<unsigned long>&, Vector<double>&);
+(Vector<double>&, Matrix<unsigned long>&, Vector<double>&);
 template void multiply<double, long long>
-(const Vector<double>&, const Matrix<long long>&, Vector<double>&);
+(Vector<double>&, Matrix<long long>&, Vector<double>&);
 template void multiply<double, unsigned long long>
-(const Vector<double>&, const Matrix<unsigned long long>&, Vector<double>&);
+(Vector<double>&, Matrix<unsigned long long>&, Vector<double>&);
 template void multiply<double, float>
-(const Vector<double>&, const Matrix<float>&, Vector<double>&);
+(Vector<double>&, Matrix<float>&, Vector<double>&);
 template void multiply<double, double>
-(const Vector<double>&, const Matrix<double>&, Vector<double>&);
+(Vector<double>&, Matrix<double>&, Vector<double>&);
 template void multiply<double, long double>
-(const Vector<double>&, const Matrix<long double>&, Vector<double>&);
+(Vector<double>&, Matrix<long double>&, Vector<double>&);
 template void multiply<long double, bool>
-(const Vector<long double>&, const Matrix<bool>&, Vector<long double>&);
+(Vector<long double>&, Matrix<bool>&, Vector<long double>&);
 template void multiply<long double, short>
-(const Vector<long double>&, const Matrix<short>&, Vector<long double>&);
+(Vector<long double>&, Matrix<short>&, Vector<long double>&);
 template void multiply<long double, unsigned short>
-(const Vector<long double>&, const Matrix<unsigned short>&, Vector<long double>&);
+(Vector<long double>&, Matrix<unsigned short>&, Vector<long double>&);
 template void multiply<long double, int>
-(const Vector<long double>&, const Matrix<int>&, Vector<long double>&);
+(Vector<long double>&, Matrix<int>&, Vector<long double>&);
 template void multiply<long double, unsigned int>
-(const Vector<long double>&, const Matrix<unsigned int>&, Vector<long double>&);
+(Vector<long double>&, Matrix<unsigned int>&, Vector<long double>&);
 template void multiply<long double, long>
-(const Vector<long double>&, const Matrix<long>&, Vector<long double>&);
+(Vector<long double>&, Matrix<long>&, Vector<long double>&);
 template void multiply<long double, unsigned long>
-(const Vector<long double>&, const Matrix<unsigned long>&, Vector<long double>&);
+(Vector<long double>&, Matrix<unsigned long>&, Vector<long double>&);
 template void multiply<long double, long long>
-(const Vector<long double>&, const Matrix<long long>&, Vector<long double>&);
+(Vector<long double>&, Matrix<long long>&, Vector<long double>&);
 template void multiply<long double, unsigned long long>
-(const Vector<long double>&, const Matrix<unsigned long long>&, Vector<long double>&);
+(Vector<long double>&, Matrix<unsigned long long>&, Vector<long double>&);
 template void multiply<long double, float>
-(const Vector<long double>&, const Matrix<float>&, Vector<long double>&);
+(Vector<long double>&, Matrix<float>&, Vector<long double>&);
 template void multiply<long double, double>
-(const Vector<long double>&, const Matrix<double>&, Vector<long double>&);
+(Vector<long double>&, Matrix<double>&, Vector<long double>&);
 template void multiply<long double, long double>
-(const Vector<long double>&, const Matrix<long double>&, Vector<long double>&);
+(Vector<long double>&, Matrix<long double>&, Vector<long double>&);
 
 #endif

--- a/adaboost/templates/instantiated_templates_operations.hpp
+++ b/adaboost/templates/instantiated_templates_operations.hpp
@@ -4,808 +4,808 @@
 template void
 Sum<bool>(
 bool (*func_ptr)(bool),
-const Vector<bool>& vec,
+Vector<bool>& vec,
 unsigned start,
 unsigned end,
 bool& result);
 template void
 Sum<short>(
 short (*func_ptr)(short),
-const Vector<short>& vec,
+Vector<short>& vec,
 unsigned start,
 unsigned end,
 short& result);
 template void
 Sum<unsigned short>(
 unsigned short (*func_ptr)(unsigned short),
-const Vector<unsigned short>& vec,
+Vector<unsigned short>& vec,
 unsigned start,
 unsigned end,
 unsigned short& result);
 template void
 Sum<int>(
 int (*func_ptr)(int),
-const Vector<int>& vec,
+Vector<int>& vec,
 unsigned start,
 unsigned end,
 int& result);
 template void
 Sum<unsigned int>(
 unsigned int (*func_ptr)(unsigned int),
-const Vector<unsigned int>& vec,
+Vector<unsigned int>& vec,
 unsigned start,
 unsigned end,
 unsigned int& result);
 template void
 Sum<long>(
 long (*func_ptr)(long),
-const Vector<long>& vec,
+Vector<long>& vec,
 unsigned start,
 unsigned end,
 long& result);
 template void
 Sum<unsigned long>(
 unsigned long (*func_ptr)(unsigned long),
-const Vector<unsigned long>& vec,
+Vector<unsigned long>& vec,
 unsigned start,
 unsigned end,
 unsigned long& result);
 template void
 Sum<long long>(
 long long (*func_ptr)(long long),
-const Vector<long long>& vec,
+Vector<long long>& vec,
 unsigned start,
 unsigned end,
 long long& result);
 template void
 Sum<unsigned long long>(
 unsigned long long (*func_ptr)(unsigned long long),
-const Vector<unsigned long long>& vec,
+Vector<unsigned long long>& vec,
 unsigned start,
 unsigned end,
 unsigned long long& result);
 template void
 Sum<float>(
 float (*func_ptr)(float),
-const Vector<float>& vec,
+Vector<float>& vec,
 unsigned start,
 unsigned end,
 float& result);
 template void
 Sum<double>(
 double (*func_ptr)(double),
-const Vector<double>& vec,
+Vector<double>& vec,
 unsigned start,
 unsigned end,
 double& result);
 template void
 Sum<long double>(
 long double (*func_ptr)(long double),
-const Vector<long double>& vec,
+Vector<long double>& vec,
 unsigned start,
 unsigned end,
 long double& result);
 void Argmax(
 bool (*func_ptr)(bool),
-const Vector<bool>& vec,
+Vector<bool>& vec,
 bool& result);
 template
 void Argmax(
 short (*func_ptr)(bool),
-const Vector<bool>& vec,
+Vector<bool>& vec,
 bool& result);
 template
 void Argmax(
 unsigned short (*func_ptr)(bool),
-const Vector<bool>& vec,
+Vector<bool>& vec,
 bool& result);
 template
 void Argmax(
 int (*func_ptr)(bool),
-const Vector<bool>& vec,
+Vector<bool>& vec,
 bool& result);
 template
 void Argmax(
 unsigned int (*func_ptr)(bool),
-const Vector<bool>& vec,
+Vector<bool>& vec,
 bool& result);
 template
 void Argmax(
 long (*func_ptr)(bool),
-const Vector<bool>& vec,
+Vector<bool>& vec,
 bool& result);
 template
 void Argmax(
 unsigned long (*func_ptr)(bool),
-const Vector<bool>& vec,
+Vector<bool>& vec,
 bool& result);
 template
 void Argmax(
 long long (*func_ptr)(bool),
-const Vector<bool>& vec,
+Vector<bool>& vec,
 bool& result);
 template
 void Argmax(
 unsigned long long (*func_ptr)(bool),
-const Vector<bool>& vec,
+Vector<bool>& vec,
 bool& result);
 template
 void Argmax(
 float (*func_ptr)(bool),
-const Vector<bool>& vec,
+Vector<bool>& vec,
 bool& result);
 template
 void Argmax(
 double (*func_ptr)(bool),
-const Vector<bool>& vec,
+Vector<bool>& vec,
 bool& result);
 template
 void Argmax(
 long double (*func_ptr)(bool),
-const Vector<bool>& vec,
+Vector<bool>& vec,
 bool& result);
 template
 void Argmax(
 bool (*func_ptr)(short),
-const Vector<short>& vec,
+Vector<short>& vec,
 short& result);
 template
 void Argmax(
 short (*func_ptr)(short),
-const Vector<short>& vec,
+Vector<short>& vec,
 short& result);
 template
 void Argmax(
 unsigned short (*func_ptr)(short),
-const Vector<short>& vec,
+Vector<short>& vec,
 short& result);
 template
 void Argmax(
 int (*func_ptr)(short),
-const Vector<short>& vec,
+Vector<short>& vec,
 short& result);
 template
 void Argmax(
 unsigned int (*func_ptr)(short),
-const Vector<short>& vec,
+Vector<short>& vec,
 short& result);
 template
 void Argmax(
 long (*func_ptr)(short),
-const Vector<short>& vec,
+Vector<short>& vec,
 short& result);
 template
 void Argmax(
 unsigned long (*func_ptr)(short),
-const Vector<short>& vec,
+Vector<short>& vec,
 short& result);
 template
 void Argmax(
 long long (*func_ptr)(short),
-const Vector<short>& vec,
+Vector<short>& vec,
 short& result);
 template
 void Argmax(
 unsigned long long (*func_ptr)(short),
-const Vector<short>& vec,
+Vector<short>& vec,
 short& result);
 template
 void Argmax(
 float (*func_ptr)(short),
-const Vector<short>& vec,
+Vector<short>& vec,
 short& result);
 template
 void Argmax(
 double (*func_ptr)(short),
-const Vector<short>& vec,
+Vector<short>& vec,
 short& result);
 template
 void Argmax(
 long double (*func_ptr)(short),
-const Vector<short>& vec,
+Vector<short>& vec,
 short& result);
 template
 void Argmax(
 bool (*func_ptr)(unsigned short),
-const Vector<unsigned short>& vec,
+Vector<unsigned short>& vec,
 unsigned short& result);
 template
 void Argmax(
 short (*func_ptr)(unsigned short),
-const Vector<unsigned short>& vec,
+Vector<unsigned short>& vec,
 unsigned short& result);
 template
 void Argmax(
 unsigned short (*func_ptr)(unsigned short),
-const Vector<unsigned short>& vec,
+Vector<unsigned short>& vec,
 unsigned short& result);
 template
 void Argmax(
 int (*func_ptr)(unsigned short),
-const Vector<unsigned short>& vec,
+Vector<unsigned short>& vec,
 unsigned short& result);
 template
 void Argmax(
 unsigned int (*func_ptr)(unsigned short),
-const Vector<unsigned short>& vec,
+Vector<unsigned short>& vec,
 unsigned short& result);
 template
 void Argmax(
 long (*func_ptr)(unsigned short),
-const Vector<unsigned short>& vec,
+Vector<unsigned short>& vec,
 unsigned short& result);
 template
 void Argmax(
 unsigned long (*func_ptr)(unsigned short),
-const Vector<unsigned short>& vec,
+Vector<unsigned short>& vec,
 unsigned short& result);
 template
 void Argmax(
 long long (*func_ptr)(unsigned short),
-const Vector<unsigned short>& vec,
+Vector<unsigned short>& vec,
 unsigned short& result);
 template
 void Argmax(
 unsigned long long (*func_ptr)(unsigned short),
-const Vector<unsigned short>& vec,
+Vector<unsigned short>& vec,
 unsigned short& result);
 template
 void Argmax(
 float (*func_ptr)(unsigned short),
-const Vector<unsigned short>& vec,
+Vector<unsigned short>& vec,
 unsigned short& result);
 template
 void Argmax(
 double (*func_ptr)(unsigned short),
-const Vector<unsigned short>& vec,
+Vector<unsigned short>& vec,
 unsigned short& result);
 template
 void Argmax(
 long double (*func_ptr)(unsigned short),
-const Vector<unsigned short>& vec,
+Vector<unsigned short>& vec,
 unsigned short& result);
 template
 void Argmax(
 bool (*func_ptr)(int),
-const Vector<int>& vec,
+Vector<int>& vec,
 int& result);
 template
 void Argmax(
 short (*func_ptr)(int),
-const Vector<int>& vec,
+Vector<int>& vec,
 int& result);
 template
 void Argmax(
 unsigned short (*func_ptr)(int),
-const Vector<int>& vec,
+Vector<int>& vec,
 int& result);
 template
 void Argmax(
 int (*func_ptr)(int),
-const Vector<int>& vec,
+Vector<int>& vec,
 int& result);
 template
 void Argmax(
 unsigned int (*func_ptr)(int),
-const Vector<int>& vec,
+Vector<int>& vec,
 int& result);
 template
 void Argmax(
 long (*func_ptr)(int),
-const Vector<int>& vec,
+Vector<int>& vec,
 int& result);
 template
 void Argmax(
 unsigned long (*func_ptr)(int),
-const Vector<int>& vec,
+Vector<int>& vec,
 int& result);
 template
 void Argmax(
 long long (*func_ptr)(int),
-const Vector<int>& vec,
+Vector<int>& vec,
 int& result);
 template
 void Argmax(
 unsigned long long (*func_ptr)(int),
-const Vector<int>& vec,
+Vector<int>& vec,
 int& result);
 template
 void Argmax(
 float (*func_ptr)(int),
-const Vector<int>& vec,
+Vector<int>& vec,
 int& result);
 template
 void Argmax(
 double (*func_ptr)(int),
-const Vector<int>& vec,
+Vector<int>& vec,
 int& result);
 template
 void Argmax(
 long double (*func_ptr)(int),
-const Vector<int>& vec,
+Vector<int>& vec,
 int& result);
 template
 void Argmax(
 bool (*func_ptr)(unsigned int),
-const Vector<unsigned int>& vec,
+Vector<unsigned int>& vec,
 unsigned int& result);
 template
 void Argmax(
 short (*func_ptr)(unsigned int),
-const Vector<unsigned int>& vec,
+Vector<unsigned int>& vec,
 unsigned int& result);
 template
 void Argmax(
 unsigned short (*func_ptr)(unsigned int),
-const Vector<unsigned int>& vec,
+Vector<unsigned int>& vec,
 unsigned int& result);
 template
 void Argmax(
 int (*func_ptr)(unsigned int),
-const Vector<unsigned int>& vec,
+Vector<unsigned int>& vec,
 unsigned int& result);
 template
 void Argmax(
 unsigned int (*func_ptr)(unsigned int),
-const Vector<unsigned int>& vec,
+Vector<unsigned int>& vec,
 unsigned int& result);
 template
 void Argmax(
 long (*func_ptr)(unsigned int),
-const Vector<unsigned int>& vec,
+Vector<unsigned int>& vec,
 unsigned int& result);
 template
 void Argmax(
 unsigned long (*func_ptr)(unsigned int),
-const Vector<unsigned int>& vec,
+Vector<unsigned int>& vec,
 unsigned int& result);
 template
 void Argmax(
 long long (*func_ptr)(unsigned int),
-const Vector<unsigned int>& vec,
+Vector<unsigned int>& vec,
 unsigned int& result);
 template
 void Argmax(
 unsigned long long (*func_ptr)(unsigned int),
-const Vector<unsigned int>& vec,
+Vector<unsigned int>& vec,
 unsigned int& result);
 template
 void Argmax(
 float (*func_ptr)(unsigned int),
-const Vector<unsigned int>& vec,
+Vector<unsigned int>& vec,
 unsigned int& result);
 template
 void Argmax(
 double (*func_ptr)(unsigned int),
-const Vector<unsigned int>& vec,
+Vector<unsigned int>& vec,
 unsigned int& result);
 template
 void Argmax(
 long double (*func_ptr)(unsigned int),
-const Vector<unsigned int>& vec,
+Vector<unsigned int>& vec,
 unsigned int& result);
 template
 void Argmax(
 bool (*func_ptr)(long),
-const Vector<long>& vec,
+Vector<long>& vec,
 long& result);
 template
 void Argmax(
 short (*func_ptr)(long),
-const Vector<long>& vec,
+Vector<long>& vec,
 long& result);
 template
 void Argmax(
 unsigned short (*func_ptr)(long),
-const Vector<long>& vec,
+Vector<long>& vec,
 long& result);
 template
 void Argmax(
 int (*func_ptr)(long),
-const Vector<long>& vec,
+Vector<long>& vec,
 long& result);
 template
 void Argmax(
 unsigned int (*func_ptr)(long),
-const Vector<long>& vec,
+Vector<long>& vec,
 long& result);
 template
 void Argmax(
 long (*func_ptr)(long),
-const Vector<long>& vec,
+Vector<long>& vec,
 long& result);
 template
 void Argmax(
 unsigned long (*func_ptr)(long),
-const Vector<long>& vec,
+Vector<long>& vec,
 long& result);
 template
 void Argmax(
 long long (*func_ptr)(long),
-const Vector<long>& vec,
+Vector<long>& vec,
 long& result);
 template
 void Argmax(
 unsigned long long (*func_ptr)(long),
-const Vector<long>& vec,
+Vector<long>& vec,
 long& result);
 template
 void Argmax(
 float (*func_ptr)(long),
-const Vector<long>& vec,
+Vector<long>& vec,
 long& result);
 template
 void Argmax(
 double (*func_ptr)(long),
-const Vector<long>& vec,
+Vector<long>& vec,
 long& result);
 template
 void Argmax(
 long double (*func_ptr)(long),
-const Vector<long>& vec,
+Vector<long>& vec,
 long& result);
 template
 void Argmax(
 bool (*func_ptr)(unsigned long),
-const Vector<unsigned long>& vec,
+Vector<unsigned long>& vec,
 unsigned long& result);
 template
 void Argmax(
 short (*func_ptr)(unsigned long),
-const Vector<unsigned long>& vec,
+Vector<unsigned long>& vec,
 unsigned long& result);
 template
 void Argmax(
 unsigned short (*func_ptr)(unsigned long),
-const Vector<unsigned long>& vec,
+Vector<unsigned long>& vec,
 unsigned long& result);
 template
 void Argmax(
 int (*func_ptr)(unsigned long),
-const Vector<unsigned long>& vec,
+Vector<unsigned long>& vec,
 unsigned long& result);
 template
 void Argmax(
 unsigned int (*func_ptr)(unsigned long),
-const Vector<unsigned long>& vec,
+Vector<unsigned long>& vec,
 unsigned long& result);
 template
 void Argmax(
 long (*func_ptr)(unsigned long),
-const Vector<unsigned long>& vec,
+Vector<unsigned long>& vec,
 unsigned long& result);
 template
 void Argmax(
 unsigned long (*func_ptr)(unsigned long),
-const Vector<unsigned long>& vec,
+Vector<unsigned long>& vec,
 unsigned long& result);
 template
 void Argmax(
 long long (*func_ptr)(unsigned long),
-const Vector<unsigned long>& vec,
+Vector<unsigned long>& vec,
 unsigned long& result);
 template
 void Argmax(
 unsigned long long (*func_ptr)(unsigned long),
-const Vector<unsigned long>& vec,
+Vector<unsigned long>& vec,
 unsigned long& result);
 template
 void Argmax(
 float (*func_ptr)(unsigned long),
-const Vector<unsigned long>& vec,
+Vector<unsigned long>& vec,
 unsigned long& result);
 template
 void Argmax(
 double (*func_ptr)(unsigned long),
-const Vector<unsigned long>& vec,
+Vector<unsigned long>& vec,
 unsigned long& result);
 template
 void Argmax(
 long double (*func_ptr)(unsigned long),
-const Vector<unsigned long>& vec,
+Vector<unsigned long>& vec,
 unsigned long& result);
 template
 void Argmax(
 bool (*func_ptr)(long long),
-const Vector<long long>& vec,
+Vector<long long>& vec,
 long long& result);
 template
 void Argmax(
 short (*func_ptr)(long long),
-const Vector<long long>& vec,
+Vector<long long>& vec,
 long long& result);
 template
 void Argmax(
 unsigned short (*func_ptr)(long long),
-const Vector<long long>& vec,
+Vector<long long>& vec,
 long long& result);
 template
 void Argmax(
 int (*func_ptr)(long long),
-const Vector<long long>& vec,
+Vector<long long>& vec,
 long long& result);
 template
 void Argmax(
 unsigned int (*func_ptr)(long long),
-const Vector<long long>& vec,
+Vector<long long>& vec,
 long long& result);
 template
 void Argmax(
 long (*func_ptr)(long long),
-const Vector<long long>& vec,
+Vector<long long>& vec,
 long long& result);
 template
 void Argmax(
 unsigned long (*func_ptr)(long long),
-const Vector<long long>& vec,
+Vector<long long>& vec,
 long long& result);
 template
 void Argmax(
 long long (*func_ptr)(long long),
-const Vector<long long>& vec,
+Vector<long long>& vec,
 long long& result);
 template
 void Argmax(
 unsigned long long (*func_ptr)(long long),
-const Vector<long long>& vec,
+Vector<long long>& vec,
 long long& result);
 template
 void Argmax(
 float (*func_ptr)(long long),
-const Vector<long long>& vec,
+Vector<long long>& vec,
 long long& result);
 template
 void Argmax(
 double (*func_ptr)(long long),
-const Vector<long long>& vec,
+Vector<long long>& vec,
 long long& result);
 template
 void Argmax(
 long double (*func_ptr)(long long),
-const Vector<long long>& vec,
+Vector<long long>& vec,
 long long& result);
 template
 void Argmax(
 bool (*func_ptr)(unsigned long long),
-const Vector<unsigned long long>& vec,
+Vector<unsigned long long>& vec,
 unsigned long long& result);
 template
 void Argmax(
 short (*func_ptr)(unsigned long long),
-const Vector<unsigned long long>& vec,
+Vector<unsigned long long>& vec,
 unsigned long long& result);
 template
 void Argmax(
 unsigned short (*func_ptr)(unsigned long long),
-const Vector<unsigned long long>& vec,
+Vector<unsigned long long>& vec,
 unsigned long long& result);
 template
 void Argmax(
 int (*func_ptr)(unsigned long long),
-const Vector<unsigned long long>& vec,
+Vector<unsigned long long>& vec,
 unsigned long long& result);
 template
 void Argmax(
 unsigned int (*func_ptr)(unsigned long long),
-const Vector<unsigned long long>& vec,
+Vector<unsigned long long>& vec,
 unsigned long long& result);
 template
 void Argmax(
 long (*func_ptr)(unsigned long long),
-const Vector<unsigned long long>& vec,
+Vector<unsigned long long>& vec,
 unsigned long long& result);
 template
 void Argmax(
 unsigned long (*func_ptr)(unsigned long long),
-const Vector<unsigned long long>& vec,
+Vector<unsigned long long>& vec,
 unsigned long long& result);
 template
 void Argmax(
 long long (*func_ptr)(unsigned long long),
-const Vector<unsigned long long>& vec,
+Vector<unsigned long long>& vec,
 unsigned long long& result);
 template
 void Argmax(
 unsigned long long (*func_ptr)(unsigned long long),
-const Vector<unsigned long long>& vec,
+Vector<unsigned long long>& vec,
 unsigned long long& result);
 template
 void Argmax(
 float (*func_ptr)(unsigned long long),
-const Vector<unsigned long long>& vec,
+Vector<unsigned long long>& vec,
 unsigned long long& result);
 template
 void Argmax(
 double (*func_ptr)(unsigned long long),
-const Vector<unsigned long long>& vec,
+Vector<unsigned long long>& vec,
 unsigned long long& result);
 template
 void Argmax(
 long double (*func_ptr)(unsigned long long),
-const Vector<unsigned long long>& vec,
+Vector<unsigned long long>& vec,
 unsigned long long& result);
 template
 void Argmax(
 bool (*func_ptr)(float),
-const Vector<float>& vec,
+Vector<float>& vec,
 float& result);
 template
 void Argmax(
 short (*func_ptr)(float),
-const Vector<float>& vec,
+Vector<float>& vec,
 float& result);
 template
 void Argmax(
 unsigned short (*func_ptr)(float),
-const Vector<float>& vec,
+Vector<float>& vec,
 float& result);
 template
 void Argmax(
 int (*func_ptr)(float),
-const Vector<float>& vec,
+Vector<float>& vec,
 float& result);
 template
 void Argmax(
 unsigned int (*func_ptr)(float),
-const Vector<float>& vec,
+Vector<float>& vec,
 float& result);
 template
 void Argmax(
 long (*func_ptr)(float),
-const Vector<float>& vec,
+Vector<float>& vec,
 float& result);
 template
 void Argmax(
 unsigned long (*func_ptr)(float),
-const Vector<float>& vec,
+Vector<float>& vec,
 float& result);
 template
 void Argmax(
 long long (*func_ptr)(float),
-const Vector<float>& vec,
+Vector<float>& vec,
 float& result);
 template
 void Argmax(
 unsigned long long (*func_ptr)(float),
-const Vector<float>& vec,
+Vector<float>& vec,
 float& result);
 template
 void Argmax(
 float (*func_ptr)(float),
-const Vector<float>& vec,
+Vector<float>& vec,
 float& result);
 template
 void Argmax(
 double (*func_ptr)(float),
-const Vector<float>& vec,
+Vector<float>& vec,
 float& result);
 template
 void Argmax(
 long double (*func_ptr)(float),
-const Vector<float>& vec,
+Vector<float>& vec,
 float& result);
 template
 void Argmax(
 bool (*func_ptr)(double),
-const Vector<double>& vec,
+Vector<double>& vec,
 double& result);
 template
 void Argmax(
 short (*func_ptr)(double),
-const Vector<double>& vec,
+Vector<double>& vec,
 double& result);
 template
 void Argmax(
 unsigned short (*func_ptr)(double),
-const Vector<double>& vec,
+Vector<double>& vec,
 double& result);
 template
 void Argmax(
 int (*func_ptr)(double),
-const Vector<double>& vec,
+Vector<double>& vec,
 double& result);
 template
 void Argmax(
 unsigned int (*func_ptr)(double),
-const Vector<double>& vec,
+Vector<double>& vec,
 double& result);
 template
 void Argmax(
 long (*func_ptr)(double),
-const Vector<double>& vec,
+Vector<double>& vec,
 double& result);
 template
 void Argmax(
 unsigned long (*func_ptr)(double),
-const Vector<double>& vec,
+Vector<double>& vec,
 double& result);
 template
 void Argmax(
 long long (*func_ptr)(double),
-const Vector<double>& vec,
+Vector<double>& vec,
 double& result);
 template
 void Argmax(
 unsigned long long (*func_ptr)(double),
-const Vector<double>& vec,
+Vector<double>& vec,
 double& result);
 template
 void Argmax(
 float (*func_ptr)(double),
-const Vector<double>& vec,
+Vector<double>& vec,
 double& result);
 template
 void Argmax(
 double (*func_ptr)(double),
-const Vector<double>& vec,
+Vector<double>& vec,
 double& result);
 template
 void Argmax(
 long double (*func_ptr)(double),
-const Vector<double>& vec,
+Vector<double>& vec,
 double& result);
 template
 void Argmax(
 bool (*func_ptr)(long double),
-const Vector<long double>& vec,
+Vector<long double>& vec,
 long double& result);
 template
 void Argmax(
 short (*func_ptr)(long double),
-const Vector<long double>& vec,
+Vector<long double>& vec,
 long double& result);
 template
 void Argmax(
 unsigned short (*func_ptr)(long double),
-const Vector<long double>& vec,
+Vector<long double>& vec,
 long double& result);
 template
 void Argmax(
 int (*func_ptr)(long double),
-const Vector<long double>& vec,
+Vector<long double>& vec,
 long double& result);
 template
 void Argmax(
 unsigned int (*func_ptr)(long double),
-const Vector<long double>& vec,
+Vector<long double>& vec,
 long double& result);
 template
 void Argmax(
 long (*func_ptr)(long double),
-const Vector<long double>& vec,
+Vector<long double>& vec,
 long double& result);
 template
 void Argmax(
 unsigned long (*func_ptr)(long double),
-const Vector<long double>& vec,
+Vector<long double>& vec,
 long double& result);
 template
 void Argmax(
 long long (*func_ptr)(long double),
-const Vector<long double>& vec,
+Vector<long double>& vec,
 long double& result);
 template
 void Argmax(
 unsigned long long (*func_ptr)(long double),
-const Vector<long double>& vec,
+Vector<long double>& vec,
 long double& result);
 template
 void Argmax(
 float (*func_ptr)(long double),
-const Vector<long double>& vec,
+Vector<long double>& vec,
 long double& result);
 template
 void Argmax(
 double (*func_ptr)(long double),
-const Vector<long double>& vec,
+Vector<long double>& vec,
 long double& result);
 template
 void Argmax(
 long double (*func_ptr)(long double),
-const Vector<long double>& vec,
+Vector<long double>& vec,
 long double& result);
-template 
-void fill(const float value, const Vector<float>&vec);
 template
-void fill(const float value, const Matrix<float>&mat); 
+void fill(float value, Vector<float>&vec);
+template
+void fill(float value, Matrix<float>&mat);
 #endif

--- a/adaboost/tests/test_cuda_data_structures.hpp
+++ b/adaboost/tests/test_cuda_data_structures.hpp
@@ -96,10 +96,10 @@ TEST(Cuda, MatricesGPU)
     EXPECT_EQ(0, mat_f.get_cols())<<"Number of columns should be 0";
     EXPECT_EQ(0, mat_f.get_rows())<<"Number of rows should be 0.";
     adaboost::cuda::core::MatrixGPU<float> mat1(3, 3), mat2(3, 3), mat3(2, 1);
+    adaboost::cuda::core::fill(float(4.0), mat1, 0, 0);
+    adaboost::cuda::core::fill(float(5.0), mat2, 0, 0);
     mat1.copy_to_device();
     mat2.copy_to_device();
-    adaboost::cuda::core::fill(float(4.0), mat1, 2);
-    adaboost::cuda::core::fill(float(5.0), mat2, 2);
     adaboost::utils::cuda::cuda_event_record(has_happened);
     adaboost::utils::cuda::cuda_event_synchronize(has_happened);
     adaboost::cuda::core::MatrixGPU<float> result1(3, 3);

--- a/adaboost/tests/test_cuda_data_structures.hpp
+++ b/adaboost/tests/test_cuda_data_structures.hpp
@@ -47,8 +47,8 @@ TEST(Cuda, MatrixGPU)
     adaboost::cuda::core::MatrixGPU<float> mat1(3, 3), mat2(3, 3), mat3(2, 1);
     mat1.copy_to_device();
     mat2.copy_to_device();
-    fill(float(4.0),mat1,0,0);
-    fill(float(5.0),mat2,0,0);
+    fill(float(4.0), mat1, 3);
+    fill(float(5.0), mat2, 3);
     mat2.copy_to_host();
     for(unsigned int i = 0; i < 3; i++)
     {
@@ -98,8 +98,8 @@ TEST(Cuda, MatricesGPU)
     adaboost::cuda::core::MatrixGPU<float> mat1(3, 3), mat2(3, 3), mat3(2, 1);
     mat1.copy_to_device();
     mat2.copy_to_device();
-    adaboost::cuda::core::fill(float(4.0), mat1, 0, 0);
-    adaboost::cuda::core::fill(float(5.0), mat2, 0, 0);
+    adaboost::cuda::core::fill(float(4.0), mat1, 2);
+    adaboost::cuda::core::fill(float(5.0), mat2, 2);
     adaboost::utils::cuda::cuda_event_record(has_happened);
     adaboost::utils::cuda::cuda_event_synchronize(has_happened);
     adaboost::cuda::core::MatrixGPU<float> result1(3, 3);

--- a/adaboost/tests/test_cuda_data_structures.hpp
+++ b/adaboost/tests/test_cuda_data_structures.hpp
@@ -4,7 +4,7 @@
 #include<adaboost/cuda/utils/cuda_wrappers.hpp>
 #include<adaboost/core/operations.hpp>
 #include<adaboost/cuda/core/operations.hpp>
-#include<stdexcept> 
+#include<stdexcept>
 
 TEST(Cuda, VectorGPU)
 {
@@ -44,15 +44,15 @@ TEST(Cuda, MatrixGPU)
     adaboost::cuda::core::MatrixGPU<float> mat_f;
     EXPECT_EQ(0, mat_f.get_cols())<<"Number of columns should be 0";
     EXPECT_EQ(0, mat_f.get_rows())<<"Number of rows should be 0.";
-    adaboost::cuda::core::MatrixGPU<float> mat1(3, 3), mat2(3, 3), mat3(2, 1);
+    adaboost::cuda::core::MatrixGPU<float> mat1(75, 75), mat2(75, 75), mat3(50, 25);
     mat1.copy_to_device();
     mat2.copy_to_device();
-    fill(float(4.0), mat1, 3);
-    fill(float(5.0), mat2, 3);
+    fill(float(4.0), mat1, 10);
+    fill(float(5.0), mat2, 16, 8);
     mat2.copy_to_host();
-    for(unsigned int i = 0; i < 3; i++)
+    for(unsigned int i = 0; i < 75; i++)
     {
-        for(unsigned int j = 0; j < 3; j++)
+        for(unsigned int j = 0; j < 75; j++)
         {
             EXPECT_EQ(5.0, mat2.at(i, j))<<"Fail at"<<i<<" "<<j;
         }
@@ -60,19 +60,20 @@ TEST(Cuda, MatrixGPU)
     mat2.copy_to_device();
     adaboost::utils::cuda::cuda_event_record(has_happened);
     adaboost::utils::cuda::cuda_event_synchronize(has_happened);
-    adaboost::cuda::core::MatrixGPU<float> result1(3, 3);
+    adaboost::cuda::core::MatrixGPU<float> result1(75, 75);
     result1.copy_to_device();
     adaboost::cuda::core::multiply_gpu(mat1, mat2, result1);
     adaboost::utils::cuda::cuda_event_record(has_happened);
     adaboost::utils::cuda::cuda_event_synchronize(has_happened);
     result1.copy_to_host();
-    for(unsigned int i = 0; i < 3; i++)
+    for(unsigned int i = 0; i < 75; i++)
     {
-        for(unsigned int j = 0; j < 3; j++)
+        for(unsigned int j = 0; j < 75; j++)
         {
-            EXPECT_EQ(60.0, result1.at(i, j));
+            EXPECT_EQ(1500.0, result1.at(i, j));
         }
     }
+    fill(float(4.0), mat3, 50);
     mat3.set(0, 0, 6.0);
     mat3.set(1, 0, 6.0);
     EXPECT_THROW({

--- a/adaboost/tests/test_cuda_data_structures.hpp
+++ b/adaboost/tests/test_cuda_data_structures.hpp
@@ -45,13 +45,23 @@ TEST(Cuda, MatrixGPU)
     EXPECT_EQ(0, mat_f.get_cols())<<"Number of columns should be 0";
     EXPECT_EQ(0, mat_f.get_rows())<<"Number of rows should be 0.";
     adaboost::cuda::core::MatrixGPU<float> mat1(3, 3), mat2(3, 3), mat3(2, 1);
+    mat1.copy_to_device();
+    mat2.copy_to_device();
     fill(float(4.0),mat1,0,0);
     fill(float(5.0),mat2,0,0);
-    mat1.copy_to_device();
+    mat2.copy_to_host();
+    for(unsigned int i = 0; i < 3; i++)
+    {
+        for(unsigned int j = 0; j < 3; j++)
+        {
+            EXPECT_EQ(5.0, mat2.at(i, j))<<"Fail at"<<i<<" "<<j;
+        }
+    }
     mat2.copy_to_device();
     adaboost::utils::cuda::cuda_event_record(has_happened);
     adaboost::utils::cuda::cuda_event_synchronize(has_happened);
     adaboost::cuda::core::MatrixGPU<float> result1(3, 3);
+    result1.copy_to_device();
     adaboost::cuda::core::multiply_gpu(mat1, mat2, result1);
     adaboost::utils::cuda::cuda_event_record(has_happened);
     adaboost::utils::cuda::cuda_event_synchronize(has_happened);
@@ -86,10 +96,10 @@ TEST(Cuda, MatricesGPU)
     EXPECT_EQ(0, mat_f.get_cols())<<"Number of columns should be 0";
     EXPECT_EQ(0, mat_f.get_rows())<<"Number of rows should be 0.";
     adaboost::cuda::core::MatrixGPU<float> mat1(3, 3), mat2(3, 3), mat3(2, 1);
-    adaboost::cuda::core::fill(float(4.0), mat1, 0, 0);
-    adaboost::cuda::core::fill(float(5.0), mat2, 0, 0);
     mat1.copy_to_device();
     mat2.copy_to_device();
+    adaboost::cuda::core::fill(float(4.0), mat1, 0, 0);
+    adaboost::cuda::core::fill(float(5.0), mat2, 0, 0);
     adaboost::utils::cuda::cuda_event_record(has_happened);
     adaboost::utils::cuda::cuda_event_synchronize(has_happened);
     adaboost::cuda::core::MatrixGPU<float> result1(3, 3);

--- a/adaboost/tests/test_data_structures.hpp
+++ b/adaboost/tests/test_data_structures.hpp
@@ -20,7 +20,7 @@ TEST(Core, Vector)
         EXPECT_EQ(4.0, vec1.at(i))<<msg2;
     }
     vec1.set(2, 6.1);
-    fill(3.0F,vec2);
+    fill(3.0F, vec2);
     vec2.set(2, 0);
     float result;
     adaboost::core::product(vec1, vec2, result);
@@ -45,8 +45,8 @@ TEST(Core, Matrices)
     EXPECT_EQ(0, mat_f.get_cols())<<"Number of columns should be 0";
     EXPECT_EQ(0, mat_f.get_rows())<<"Number of rows should be 0.";
     adaboost::core::Matrix<float> mat1(3, 3), mat2(3, 3), mat3(2, 1);
-    fill(4.0F,mat1);
-    fill(5.0F,mat2);
+    fill(4.0F, mat1);
+    fill(5.0F, mat2);
     adaboost::core::Matrix<float> result1(3, 3);
     adaboost::core::multiply(mat1, mat2, result1);
     for(unsigned int i = 0; i < 3; i++)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs or Relevant literature
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #2 

#### Brief description of what is fixed or changed
Implementing filling matrix in `adaboost::cuda::core` by using non default streams. Number of streams is passed as a parameter to the function, and each row of matrix gets filled by one of the streams. The stream to fill is chosen in a round robin fashion.

#### Other comments
Initial code of filling using `n` streams was by @fiza11. @Tanvi141  worked on integrating that code into this code base as well as implementing round robin.